### PR TITLE
Fix beat API route and remove unsupported save calls

### DIFF
--- a/client/src/components/producer/BeatMaker.tsx
+++ b/client/src/components/producer/BeatMaker.tsx
@@ -3,7 +3,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Play, Pause, Square, Save, Zap, Volume2, Settings } from 'lucide-react';
+import { Play, Pause, Zap } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useMutation } from '@tanstack/react-query';
 import { beatAPI } from '@/lib/api';
@@ -139,38 +139,9 @@ const BeatMaker: React.FC<BeatMakerProps> = ({ onBeatGenerated }) => {
     },
   });
 
-  // Save beat mutation
-  const saveBeatMutation = useMutation({
-    mutationFn: async () => {
-      return beatAPI.save({
-        name: `Beat_${new Date().toISOString().slice(0, 10)}_${bpm}BPM`,
-        pattern,
-        bpm,
-      });
-    },
-    onSuccess: () => {
-      toast({
-        title: "Beat Saved!",
-        description: "Your beat has been saved successfully",
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: "Save Failed",
-        description: error.message || "Failed to save beat",
-        variant: "destructive",
-      });
-    },
-  });
-
   // Handle beat generation
   const handleGenerateAI = () => {
     generateBeatMutation.mutate();
-  };
-
-  // Handle saving
-  const handleSave = () => {
-    saveBeatMutation.mutate();
   };
 
   const toggleStep = (track: keyof BeatPattern, stepIndex: number) => {
@@ -400,15 +371,6 @@ const BeatMaker: React.FC<BeatMakerProps> = ({ onBeatGenerated }) => {
                   >
                     {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
                     <span>{isPlaying ? 'Stop' : 'Play'}</span>
-                  </Button>
-                  <Button
-                    onClick={handleSave}
-                    disabled={saveBeatMutation.isPending}
-                    variant="outline"
-                    className="flex items-center space-x-2"
-                  >
-                    <Save className="w-4 h-4" />
-                    <span>Save</span>
                   </Button>
                 </div>
               </div>

--- a/client/src/components/studio/BeatMaker.tsx
+++ b/client/src/components/studio/BeatMaker.tsx
@@ -179,44 +179,9 @@ export default function BeatMaker() {
     },
   });
 
-  // Save beat mutation
-  const saveBeatMutation = useMutation({
-    mutationFn: async () => {
-      const response = await apiRequest("POST", "/api/beat/save", {
-        pattern,
-        bpm,
-        name: `Beat_${new Date().toISOString().slice(0, 10)}_${bpm}BPM`
-      });
-      
-      if (!response.ok) {
-        throw new Error("Failed to save beat");
-      }
-      
-      return response.json();
-    },
-    onSuccess: () => {
-      toast({
-        title: "Beat Saved!",
-        description: "Your beat has been saved successfully",
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: "Save Failed",
-        description: error.message || "Failed to save beat",
-        variant: "destructive",
-      });
-    },
-  });
-
   // Handle beat generation
   const handleGenerateAI = () => {
     generateBeatMutation.mutate();
-  };
-
-  // Handle saving
-  const handleSave = () => {
-    saveBeatMutation.mutate();
   };
 
   const toggleStep = (track: keyof BeatPattern, stepIndex: number) => {
@@ -403,40 +368,23 @@ export default function BeatMaker() {
               </div>
               
               {/* Controls */}
-              <div className="flex items-center space-x-4 mb-4">
-                <Button
-                  onClick={initialize}
-                  disabled={isInitialized}
-                  className="bg-studio-accent hover:bg-blue-500"
-                >
-                  <i className="fas fa-power-off mr-2"></i>
-                  {isInitialized ? 'Audio Ready' : 'Start Audio'}
-                </Button>
-                <Button
-                  onClick={playPattern}
-                  className={`${isPlaying ? 'bg-red-600 hover:bg-red-500' : 'bg-studio-success hover:bg-green-500'}`}
-                >
-                  <i className={`fas ${isPlaying ? 'fa-stop' : 'fa-play'} mr-2`}></i>
-                  {isPlaying ? 'Stop' : 'Play'}
-                </Button>
-                <Button
-                  onClick={handleSave}
-                  disabled={saveBeatMutation.isPending}
-                  className="bg-gray-600 hover:bg-gray-500"
-                >
-                  {saveBeatMutation.isPending ? (
-                    <>
-                      <i className="fas fa-spinner animate-spin mr-2"></i>
-                      Saving...
-                    </>
-                  ) : (
-                    <>
-                      <i className="fas fa-save mr-2"></i>
-                      Save Beat
-                    </>
-                  )}
-                </Button>
-              </div>
+                <div className="flex items-center space-x-4 mb-4">
+                  <Button
+                    onClick={initialize}
+                    disabled={isInitialized}
+                    className="bg-studio-accent hover:bg-blue-500"
+                  >
+                    <i className="fas fa-power-off mr-2"></i>
+                    {isInitialized ? 'Audio Ready' : 'Start Audio'}
+                  </Button>
+                  <Button
+                    onClick={playPattern}
+                    className={`${isPlaying ? 'bg-red-600 hover:bg-red-500' : 'bg-studio-success hover:bg-green-500'}`}
+                  >
+                    <i className={`fas ${isPlaying ? 'fa-stop' : 'fa-play'} mr-2`}></i>
+                    {isPlaying ? 'Stop' : 'Play'}
+                  </Button>
+                </div>
               
               {/* Visual Time Indicator */}
               {isPlaying && (

--- a/client/src/components/studio/HybridWorkflow.tsx
+++ b/client/src/components/studio/HybridWorkflow.tsx
@@ -52,7 +52,7 @@ export default function HybridWorkflow() {
   // AI Generation Mutations
   const generateBeatMutation = useMutation({
     mutationFn: async (data: { style: string; bpm: number; complexity: number }) => {
-      const response = await apiRequest('POST', '/api/beats/generate', data);
+      const response = await apiRequest('POST', '/api/beat/generate', data);
       return await response.json();
     },
     onSuccess: (beat) => {

--- a/client/src/components/studio/ProfessionalStudio.tsx
+++ b/client/src/components/studio/ProfessionalStudio.tsx
@@ -134,7 +134,7 @@ export default function ProfessionalStudio() {
 
   const generateAIBeatMutation = useMutation({
     mutationFn: async (data: { style: string; lyrics?: string; bpm?: number; complexity?: number }) => {
-      const response = await apiRequest('POST', '/api/beats/generate', data);
+      const response = await apiRequest('POST', '/api/beat/generate', data);
       return await response.json();
     },
     onSuccess: (result) => {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -5,7 +5,7 @@ export const beatAPI = {
     duration: number;
     aiProvider: string;
   }) {
-    const response = await fetch("/api/beats/generate", {
+    const response = await fetch("/api/beat/generate", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -15,36 +15,6 @@ export const beatAPI = {
 
     if (!response.ok) {
       throw new Error(`Beat generation failed: ${response.statusText}`);
-    }
-
-    return response.json();
-  },
-
-  async save(params: {
-    name: string;
-    pattern: any;
-    bpm: number;
-  }) {
-    const response = await fetch("/api/beats", {
-      method: "POST", 
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(params),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Beat save failed: ${response.statusText}`);
-    }
-
-    return response.json();
-  },
-
-  async list() {
-    const response = await fetch("/api/beats");
-    
-    if (!response.ok) {
-      throw new Error(`Failed to fetch beats: ${response.statusText}`);
     }
 
     return response.json();

--- a/music-plugin-manager/src/components/studio/BeatMaker.tsx
+++ b/music-plugin-manager/src/components/studio/BeatMaker.tsx
@@ -179,44 +179,9 @@ export default function BeatMaker() {
     },
   });
 
-  // Save beat mutation
-  const saveBeatMutation = useMutation({
-    mutationFn: async () => {
-      const response = await apiRequest("POST", "/api/beat/save", {
-        pattern,
-        bpm,
-        name: `Beat_${new Date().toISOString().slice(0, 10)}_${bpm}BPM`
-      });
-      
-      if (!response.ok) {
-        throw new Error("Failed to save beat");
-      }
-      
-      return response.json();
-    },
-    onSuccess: () => {
-      toast({
-        title: "Beat Saved!",
-        description: "Your beat has been saved successfully",
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: "Save Failed",
-        description: error.message || "Failed to save beat",
-        variant: "destructive",
-      });
-    },
-  });
-
   // Handle beat generation
   const handleGenerateAI = () => {
     generateBeatMutation.mutate();
-  };
-
-  // Handle saving
-  const handleSave = () => {
-    saveBeatMutation.mutate();
   };
 
   const toggleStep = (track: keyof BeatPattern, stepIndex: number) => {
@@ -403,40 +368,23 @@ export default function BeatMaker() {
               </div>
               
               {/* Controls */}
-              <div className="flex items-center space-x-4 mb-4">
-                <Button
-                  onClick={initialize}
-                  disabled={isInitialized}
-                  className="bg-studio-accent hover:bg-blue-500"
-                >
-                  <i className="fas fa-power-off mr-2"></i>
-                  {isInitialized ? 'Audio Ready' : 'Start Audio'}
-                </Button>
-                <Button
-                  onClick={playPattern}
-                  className={`${isPlaying ? 'bg-red-600 hover:bg-red-500' : 'bg-studio-success hover:bg-green-500'}`}
-                >
-                  <i className={`fas ${isPlaying ? 'fa-stop' : 'fa-play'} mr-2`}></i>
-                  {isPlaying ? 'Stop' : 'Play'}
-                </Button>
-                <Button
-                  onClick={handleSave}
-                  disabled={saveBeatMutation.isPending}
-                  className="bg-gray-600 hover:bg-gray-500"
-                >
-                  {saveBeatMutation.isPending ? (
-                    <>
-                      <i className="fas fa-spinner animate-spin mr-2"></i>
-                      Saving...
-                    </>
-                  ) : (
-                    <>
-                      <i className="fas fa-save mr-2"></i>
-                      Save Beat
-                    </>
-                  )}
-                </Button>
-              </div>
+                <div className="flex items-center space-x-4 mb-4">
+                  <Button
+                    onClick={initialize}
+                    disabled={isInitialized}
+                    className="bg-studio-accent hover:bg-blue-500"
+                  >
+                    <i className="fas fa-power-off mr-2"></i>
+                    {isInitialized ? 'Audio Ready' : 'Start Audio'}
+                  </Button>
+                  <Button
+                    onClick={playPattern}
+                    className={`${isPlaying ? 'bg-red-600 hover:bg-red-500' : 'bg-studio-success hover:bg-green-500'}`}
+                  >
+                    <i className={`fas ${isPlaying ? 'fa-stop' : 'fa-play'} mr-2`}></i>
+                    {isPlaying ? 'Stop' : 'Play'}
+                  </Button>
+                </div>
               
               {/* Visual Time Indicator */}
               {isPlaying && (

--- a/music-plugin-manager/src/components/studio/ProfessionalStudio.tsx
+++ b/music-plugin-manager/src/components/studio/ProfessionalStudio.tsx
@@ -134,7 +134,7 @@ export default function ProfessionalStudio() {
 
   const generateAIBeatMutation = useMutation({
     mutationFn: async (data: { style: string; lyrics?: string; bpm?: number; complexity?: number }) => {
-      const response = await apiRequest('POST', '/api/beats/generate', data);
+      const response = await apiRequest('POST', '/api/beat/generate', data);
       return await response.json();
     },
     onSuccess: (result) => {

--- a/music-plugin-manager/src/lib/api.ts
+++ b/music-plugin-manager/src/lib/api.ts
@@ -5,7 +5,7 @@ export const beatAPI = {
     duration: number;
     aiProvider: string;
   }) {
-    const response = await fetch("/api/beats/generate", {
+    const response = await fetch("/api/beat/generate", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -15,36 +15,6 @@ export const beatAPI = {
 
     if (!response.ok) {
       throw new Error(`Beat generation failed: ${response.statusText}`);
-    }
-
-    return response.json();
-  },
-
-  async save(params: {
-    name: string;
-    pattern: any;
-    bpm: number;
-  }) {
-    const response = await fetch("/api/beats", {
-      method: "POST", 
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(params),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Beat save failed: ${response.statusText}`);
-    }
-
-    return response.json();
-  },
-
-  async list() {
-    const response = await fetch("/api/beats");
-    
-    if (!response.ok) {
-      throw new Error(`Failed to fetch beats: ${response.statusText}`);
     }
 
     return response.json();


### PR DESCRIPTION
## Summary
- point beat API requests to singular `/api/beat/generate`
- drop unsupported beat save/list features and UI
- ensure studio components use updated beat endpoint

## Testing
- `npm run build`
- `cd music-plugin-manager && npm run build` *(fails: Could not resolve vite.config.prod.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c5610674832788bf2b3b57346ccd