### PR TITLE
feat(organism): natural language vibe interpreter (Feature 2 — Phase 1)

### DIFF
--- a/client/src/features/organism/ArtistReferenceBank.ts
+++ b/client/src/features/organism/ArtistReferenceBank.ts
@@ -1,0 +1,259 @@
+/**
+ * ArtistReferenceBank
+ *
+ * Rule-based fallback interpreter for the Natural Language Vibe feature.
+ * Used when the AI endpoint (/api/organism/interpret-vibe) is unavailable.
+ *
+ * No async calls, no external dependencies — deterministic and instant.
+ * Covers artist references, genre keywords, and energy/mood modifiers.
+ */
+
+export interface VibeParams {
+  bpm:            number
+  mode:           'heat' | 'ice' | 'smoke' | 'gravel' | 'glow'
+  subGenre:       string
+  energy:         number
+  swing:          number
+  bounce:         number
+  density:        number
+  interpretation: string
+  confidence:     number
+}
+
+// ── Artist reference map ───────────────────────────────────────────────────
+// Each entry captures the musical DNA of that artist's signature sound.
+// Parameters derived from their most iconic production style.
+
+const ARTIST_REFS: Array<{ keys: string[]; params: VibeParams }> = [
+  {
+    keys: ['tupac', '2pac', 'pac'],
+    params: { bpm: 90, mode: 'gravel', subGenre: 'west-coast', energy: 0.60, swing: 0.55, bounce: 0.50, density: 0.40,
+      interpretation: 'West coast boom-bap — soulful, heavy swing, 90 BPM', confidence: 0.92 },
+  },
+  {
+    keys: ['eminem', 'slim shady', 'marshall'],
+    params: { bpm: 105, mode: 'heat', subGenre: 'boom-bap', energy: 0.80, swing: 0.45, bounce: 0.60, density: 0.60,
+      interpretation: 'Detroit boom-bap — aggressive, driving, 105 BPM', confidence: 0.92 },
+  },
+  {
+    keys: ['drake', 'drizzy'],
+    params: { bpm: 80, mode: 'glow', subGenre: 'chill', energy: 0.40, swing: 0.60, bounce: 0.40, density: 0.30,
+      interpretation: 'Drake vibes — smooth, melodic, chill, 80 BPM', confidence: 0.92 },
+  },
+  {
+    keys: ['kendrick', 'kdot', 'kendrick lamar'],
+    params: { bpm: 88, mode: 'gravel', subGenre: 'boom-bap', energy: 0.65, swing: 0.65, bounce: 0.55, density: 0.50,
+      interpretation: 'Kendrick conscious boom-bap — complex, soulful, 88 BPM', confidence: 0.92 },
+  },
+  {
+    keys: ['travis', 'travis scott', 'la flame', 'cactus jack'],
+    params: { bpm: 140, mode: 'ice', subGenre: 'trap', energy: 0.80, swing: 0.30, bounce: 0.70, density: 0.70,
+      interpretation: 'Travis trap — atmospheric, hypnotic, 140 BPM', confidence: 0.92 },
+  },
+  {
+    keys: ['j cole', 'jcole', 'cole'],
+    params: { bpm: 85, mode: 'glow', subGenre: 'boom-bap', energy: 0.55, swing: 0.60, bounce: 0.50, density: 0.40,
+      interpretation: 'J Cole boom-bap — thoughtful, warm, 85 BPM', confidence: 0.90 },
+  },
+  {
+    keys: ['future', 'future hendrix', 'freebandz'],
+    params: { bpm: 130, mode: 'ice', subGenre: 'trap', energy: 0.75, swing: 0.35, bounce: 0.65, density: 0.65,
+      interpretation: 'Future trap — hazy, melodic, dark, 130 BPM', confidence: 0.90 },
+  },
+  {
+    keys: ['nas', 'nasty nas'],
+    params: { bpm: 92, mode: 'gravel', subGenre: 'boom-bap', energy: 0.60, swing: 0.50, bounce: 0.45, density: 0.45,
+      interpretation: 'Nas classic boom-bap — raw, lyrical, 92 BPM', confidence: 0.90 },
+  },
+  {
+    keys: ['21 savage', '21savage', 'savage'],
+    params: { bpm: 140, mode: 'heat', subGenre: 'trap', energy: 0.75, swing: 0.30, bounce: 0.60, density: 0.65,
+      interpretation: '21 Savage trap — dark, minimal, hard, 140 BPM', confidence: 0.88 },
+  },
+  {
+    keys: ['pop smoke', 'pop'],
+    params: { bpm: 140, mode: 'gravel', subGenre: 'drill', energy: 0.85, swing: 0.25, bounce: 0.70, density: 0.70,
+      interpretation: 'UK drill — heavy, dark, menacing, 140 BPM', confidence: 0.90 },
+  },
+  {
+    keys: ['chief keef', 'keef'],
+    params: { bpm: 145, mode: 'gravel', subGenre: 'drill', energy: 0.90, swing: 0.20, bounce: 0.75, density: 0.75,
+      interpretation: 'Chicago drill — hard, relentless, 145 BPM', confidence: 0.90 },
+  },
+  {
+    keys: ['gunna', 'wunna', 'drip or drown'],
+    params: { bpm: 142, mode: 'ice', subGenre: 'trap', energy: 0.70, swing: 0.30, bounce: 0.65, density: 0.60,
+      interpretation: 'Gunna drip trap — smooth, cool, 142 BPM', confidence: 0.88 },
+  },
+  {
+    keys: ['lil baby', 'lilbaby'],
+    params: { bpm: 142, mode: 'heat', subGenre: 'trap', energy: 0.78, swing: 0.28, bounce: 0.65, density: 0.65,
+      interpretation: 'Lil Baby trap — melodic, energetic, 142 BPM', confidence: 0.88 },
+  },
+  {
+    keys: ['polo g', 'polo'],
+    params: { bpm: 138, mode: 'ice', subGenre: 'trap', energy: 0.72, swing: 0.30, bounce: 0.60, density: 0.55,
+      interpretation: 'Polo G melodic trap — introspective, 138 BPM', confidence: 0.88 },
+  },
+  {
+    keys: ['rod wave', 'rodwave'],
+    params: { bpm: 80, mode: 'glow', subGenre: 'chill', energy: 0.45, swing: 0.55, bounce: 0.40, density: 0.35,
+      interpretation: 'Rod Wave emotional — slow, soulful, 80 BPM', confidence: 0.88 },
+  },
+  {
+    keys: ['playboi carti', 'carti', 'opium'],
+    params: { bpm: 140, mode: 'ice', subGenre: 'trap', energy: 0.85, swing: 0.20, bounce: 0.80, density: 0.75,
+      interpretation: 'Carti trap — hypnotic, bouncy, 140 BPM', confidence: 0.88 },
+  },
+]
+
+// ── Genre keyword map ──────────────────────────────────────────────────────
+// Matched in order — first match wins.
+
+const GENRE_REFS: Array<{ keys: string[]; partial: Partial<VibeParams> & { interpretation: string } }> = [
+  {
+    keys: ['uk drill', 'ukdrill'],
+    partial: { bpm: 140, mode: 'gravel', subGenre: 'drill', energy: 0.88, swing: 0.22, bounce: 0.72, density: 0.72,
+      interpretation: 'UK drill — dark, heavy, 140 BPM', confidence: 0.85 },
+  },
+  {
+    keys: ['chicago drill', 'chi drill'],
+    partial: { bpm: 145, mode: 'gravel', subGenre: 'drill', energy: 0.90, swing: 0.20, bounce: 0.75, density: 0.75,
+      interpretation: 'Chicago drill — relentless, 145 BPM', confidence: 0.85 },
+  },
+  {
+    keys: ['drill'],
+    partial: { bpm: 145, mode: 'gravel', subGenre: 'drill', energy: 0.87, swing: 0.22, bounce: 0.72, density: 0.72,
+      interpretation: 'Drill — dark, offbeat hats, 145 BPM', confidence: 0.82 },
+  },
+  {
+    keys: ['phonk'],
+    partial: { bpm: 130, mode: 'heat', subGenre: 'phonk', energy: 0.80, swing: 0.40, bounce: 0.70, density: 0.70,
+      interpretation: 'Phonk — Memphis dark, cowbell, 130 BPM', confidence: 0.83 },
+  },
+  {
+    keys: ['boom bap', 'boom-bap', 'boomba'],
+    partial: { bpm: 90, mode: 'smoke', subGenre: 'boom-bap', energy: 0.60, swing: 0.60, bounce: 0.50, density: 0.45,
+      interpretation: 'Classic boom-bap — heavy swing, 90 BPM', confidence: 0.83 },
+  },
+  {
+    keys: ['west coast', 'westcoast', 'g-funk', 'gfunk'],
+    partial: { bpm: 90, mode: 'gravel', subGenre: 'west-coast', energy: 0.60, swing: 0.55, bounce: 0.50, density: 0.40,
+      interpretation: 'West coast G-funk — soulful bounce, 90 BPM', confidence: 0.83 },
+  },
+  {
+    keys: ['lo-fi', 'lofi', 'lo fi', 'chillhop'],
+    partial: { bpm: 78, mode: 'ice', subGenre: 'lo-fi', energy: 0.35, swing: 0.65, bounce: 0.35, density: 0.30,
+      interpretation: 'Lo-fi beats — dusty, warm, 78 BPM', confidence: 0.83 },
+  },
+  {
+    keys: ['dirty south', 'dirtysouth', 'crunk'],
+    partial: { bpm: 100, mode: 'smoke', subGenre: 'dirty-south', energy: 0.72, swing: 0.45, bounce: 0.65, density: 0.65,
+      interpretation: 'Dirty south — heavy bass, call-response, 100 BPM', confidence: 0.83 },
+  },
+  {
+    keys: ['trap'],
+    partial: { bpm: 140, mode: 'heat', subGenre: 'trap', energy: 0.75, swing: 0.30, bounce: 0.65, density: 0.65,
+      interpretation: 'Trap — 808s, hats, 140 BPM', confidence: 0.80 },
+  },
+  {
+    keys: ['chill', 'relaxed', 'laid back', 'laid-back'],
+    partial: { bpm: 80, mode: 'glow', subGenre: 'chill', energy: 0.35, swing: 0.50, bounce: 0.40, density: 0.30,
+      interpretation: 'Chill — sparse, atmospheric, 80 BPM', confidence: 0.80 },
+  },
+]
+
+// ── Mood modifiers ─────────────────────────────────────────────────────────
+// These stack on top of whatever base was matched.
+// Numeric values are deltas (+ or -).
+
+interface MoodMod {
+  bpmDelta?:     number
+  energyDelta?:  number
+  swingDelta?:   number
+  bounceDelta?:  number
+  densityDelta?: number
+  mode?:         VibeParams['mode']
+}
+
+const MOOD_MODS: Array<{ keys: string[]; mod: MoodMod }> = [
+  { keys: ['fired up', 'fire', 'lit', 'hype', 'hyped'],  mod: { energyDelta: 0.15, densityDelta: 0.10, bounceDelta: 0.10 } },
+  { keys: ['aggressive', 'aggro'],                       mod: { energyDelta: 0.20, densityDelta: 0.15, bounceDelta: 0.10 } },
+  { keys: ['hard'],                                      mod: { energyDelta: 0.12, densityDelta: 0.10 } },
+  { keys: ['dark'],                                      mod: { energyDelta: -0.10, mode: 'gravel' } },
+  { keys: ['icy', 'cold', 'frozen', 'ice'],              mod: { mode: 'ice', energyDelta: -0.05 } },
+  { keys: ['drip'],                                      mod: { mode: 'ice', energyDelta: 0.05 } },
+  { keys: ['raw', 'gritty'],                             mod: { mode: 'gravel', energyDelta: 0.08 } },
+  { keys: ['smooth'],                                    mod: { energyDelta: -0.08, swingDelta: 0.10 } },
+  { keys: ['punchy'],                                    mod: { bounceDelta: 0.15, densityDelta: 0.10 } },
+  { keys: ['story beat', 'story', 'cinematic'],          mod: { bpmDelta: -15, densityDelta: -0.15, swingDelta: 0.10 } },
+  { keys: ['soulful'],                                   mod: { swingDelta: 0.15, mode: 'smoke' } },
+  { keys: ['melodic'],                                   mod: { mode: 'glow', energyDelta: -0.05 } },
+  { keys: ['faster', 'fast', 'double time'],             mod: { bpmDelta: 20 } },
+  { keys: ['slower', 'slow', 'half time'],               mod: { bpmDelta: -20 } },
+]
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function clamp01(v: number): number { return Math.max(0, Math.min(1, v)) }
+function clampBpm(v: number): number { return Math.max(60, Math.min(200, v)) }
+
+function normalizeText(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+// ── Main export ────────────────────────────────────────────────────────────
+
+/**
+ * Rule-based fallback interpreter.
+ *
+ * Scans free-text for artist names, genre terms, and mood descriptors.
+ * Returns a VibeParams object ready to apply to the organism.
+ * Always returns a valid result — falls back to a default if nothing matches.
+ */
+export function interpretVibeRuleBased(text: string): VibeParams {
+  const normalized = normalizeText(text)
+
+  // 1. Check artist references first (highest confidence)
+  for (const { keys, params } of ARTIST_REFS) {
+    if (keys.some(k => normalized.includes(k))) {
+      return applyMoodMods(normalized, { ...params })
+    }
+  }
+
+  // 2. Genre keyword match
+  let base: VibeParams = {
+    bpm: 90, mode: 'heat', subGenre: 'trap',
+    energy: 0.65, swing: 0.45, bounce: 0.60, density: 0.60,
+    interpretation: 'Hip-hop beat', confidence: 0.50,
+  }
+
+  for (const { keys, partial } of GENRE_REFS) {
+    if (keys.some(k => normalized.includes(k))) {
+      base = { ...base, ...partial }
+      break
+    }
+  }
+
+  // 3. Stack mood modifiers
+  return applyMoodMods(normalized, base)
+}
+
+function applyMoodMods(normalized: string, base: VibeParams): VibeParams {
+  let bpmDelta = 0
+  const result = { ...base }
+
+  for (const { keys, mod } of MOOD_MODS) {
+    if (keys.some(k => normalized.includes(k))) {
+      if (mod.bpmDelta     !== undefined) bpmDelta           += mod.bpmDelta
+      if (mod.energyDelta  !== undefined) result.energy       = clamp01(result.energy  + mod.energyDelta)
+      if (mod.swingDelta   !== undefined) result.swing        = clamp01(result.swing   + mod.swingDelta)
+      if (mod.bounceDelta  !== undefined) result.bounce       = clamp01(result.bounce  + mod.bounceDelta)
+      if (mod.densityDelta !== undefined) result.density      = clamp01(result.density + mod.densityDelta)
+      if (mod.mode         !== undefined) result.mode         = mod.mode
+    }
+  }
+
+  result.bpm = clampBpm(result.bpm + bpmDelta)
+  return result
+}

--- a/client/src/features/organism/OrganismCommandCenter.tsx
+++ b/client/src/features/organism/OrganismCommandCenter.tsx
@@ -8,13 +8,58 @@
  * Voice command (mic button) is stubbed here — wired in Feature 2.
  */
 
-import React, { useRef, useEffect, useState, useCallback } from 'react'
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react'
 import { Link } from 'wouter'
 import { useOrganism, useOrganismPhysics } from './OrganismContext'
 import { OrganismVisualizer } from './OrganismVisualizer'
 import { InputSourceSelector } from './InputSourceSelector'
 import { useOrganismShortcuts } from './useOrganismShortcuts'
 import { OState } from '../../organism/state/types'
+import { useStudioStore } from '../../stores/useStudioStore'
+
+// ── Web Speech API local typings ───────────────────────────────────────────
+// The browser's SpeechRecognition is experimental — TS lib doesn't always
+// provide it, and ESLint's no-undef flags the DOM globals even when TS knows
+// them. These minimal interfaces capture just the surface we use below.
+
+interface SpeechRecognitionAlternativeLike {
+  transcript: string
+}
+
+interface SpeechRecognitionResultLike {
+  readonly length: number
+  readonly isFinal: boolean
+  readonly [index: number]: SpeechRecognitionAlternativeLike
+}
+
+interface SpeechRecognitionResultListLike {
+  readonly length: number
+  readonly [index: number]: SpeechRecognitionResultLike
+}
+
+interface SpeechRecognitionEventLike {
+  resultIndex: number
+  results: SpeechRecognitionResultListLike
+}
+
+interface SpeechRecognitionLike {
+  continuous:     boolean
+  interimResults: boolean
+  lang:           string
+  onstart:  (() => void) | null
+  onend:    (() => void) | null
+  onerror:  (() => void) | null
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null
+  start: () => void
+  stop:  () => void
+}
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike
+
+interface SpeechRecognitionWindow {
+  SpeechRecognition?:       SpeechRecognitionCtor
+  webkitSpeechRecognition?: SpeechRecognitionCtor
+}
 
 // ── Style constants ────────────────────────────────────────────────────────────
 
@@ -119,11 +164,10 @@ export function OrganismCommandCenter() {
   useOrganismShortcuts()
 
   const {
-    start, stop, isRunning, error,
+    stop, isRunning, error,
     quickStartPresets, activePresetId, swapPreset, countInStart, countInBeat,
     soundTriggerArmed, armSoundTrigger, disarmSoundTrigger,
-    isRecording, startRecording, stopRecording, lastSavedSession, downloadSession,
-    savedSessions,
+    isRecording, startRecording, stopRecording,
     // Tweak controls
     hatDensity,   setHatDensity,
     kickVelocity, setKickVelocity,
@@ -140,20 +184,132 @@ export function OrganismCommandCenter() {
     // Report card
     lastReport, generateReport,
     // Session
-    lastSessionDNA, capture, downloadMidi,
+    lastSessionDNA, capture,
     shareSession, isSharingSession, lastSharedPostUrl,
     // Input
     inputSource, setInputSource, autoEnergy, setAutoEnergy,
     // Guest
-    guestSecondsRemaining, isGuestNudgeVisible, dismissGuestNudge,
+    isGuestNudgeVisible, dismissGuestNudge,
     // Vibe
     currentVibe,
+    // Vibe Interpreter
+    interpretVibe,
+    vibeInterpretation,
+    // Engines (for direct mode + technique control)
+    physicsEngine,
+    orchestrator,
+    reactiveBehaviors,
   } = useOrganism()
 
-  const { physicsState, organismState, meterReading } = useOrganismPhysics()
+  const { physicsState, organismState } = useOrganismPhysics()
+
+  // ── Voice command state ──────────────────────────────────────────────────
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null)
+  const [isListening,  setIsListening]  = useState(false)
+  const [vibeText,     setVibeText]     = useState('')
+  const [vibeStatus,   setVibeStatus]   = useState<'idle' | 'interpreting' | 'done'>('idle')
+
+  // Resolve the SpeechRecognition constructor once — null when unsupported.
+  const SpeechRecognitionCtor = useMemo<SpeechRecognitionCtor | null>(() => {
+    if (typeof window === 'undefined') return null
+    const w = window as unknown as SpeechRecognitionWindow
+    return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null
+  }, [])
+  const hasSpeechRecognition = SpeechRecognitionCtor !== null
+
+  const toggleListening = useCallback(() => {
+    if (isListening) {
+      recognitionRef.current?.stop()
+      setIsListening(false)
+      return
+    }
+
+    if (!SpeechRecognitionCtor) return
+
+    const recog = new SpeechRecognitionCtor()
+    recog.continuous      = false
+    recog.interimResults  = true
+    recog.lang            = 'en-US'
+
+    recog.onstart = () => {
+      setIsListening(true)
+      setVibeText('')
+      setVibeStatus('idle')
+    }
+    recog.onend = () => setIsListening(false)
+    recog.onerror = () => {
+      setIsListening(false)
+      setVibeStatus('idle')
+    }
+
+    recog.onresult = async (event: SpeechRecognitionEventLike) => {
+      let interim = ''
+      let final   = ''
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const r = event.results[i]
+        if (r.isFinal) final   += r[0].transcript
+        else           interim += r[0].transcript
+      }
+      const current = final || interim
+      setVibeText(current)
+
+      if (final) {
+        setVibeStatus('interpreting')
+        await interpretVibe(final.trim())
+        setVibeStatus('done')
+      }
+    }
+
+    recognitionRef.current = recog
+    recog.start()
+  }, [isListening, interpretVibe, SpeechRecognitionCtor])
+
+  // ── Mode + Technique state ───────────────────────────────────────────────
+  const [lockedMode,   setLockedMode]   = useState<string | null>(null)
+  const [chordTech,    setChordTechLocal]  = useState('piano-block-chord')
+  const [melodyArt,    setMelodyArtLocal]  = useState('none')
+  const [bassArt,      setBassArtLocal]    = useState('none')
+  const [styleShifts,  setStyleShiftsLocal] = useState(true)
+  const [bpmInput,     setBpmInput]     = useState('')
+
+  const applyMode = useCallback((mode: string | null) => {
+    setLockedMode(mode)
+    if (mode) physicsEngine?.lockMode(mode as import('../../organism/physics/types').OrganismMode)
+    else       physicsEngine?.unlockMode()
+  }, [physicsEngine])
+
+  const applyChordTech = useCallback((id: string) => {
+    setChordTechLocal(id)
+    orchestrator?.setChordTechnique(id)
+  }, [orchestrator])
+
+  const applyMelodyArt = useCallback((id: string) => {
+    setMelodyArtLocal(id)
+    orchestrator?.setMelodyArticulation(id)
+  }, [orchestrator])
+
+  const applyBassArt = useCallback((id: string) => {
+    setBassArtLocal(id)
+    orchestrator?.setBassArticulation(id)
+  }, [orchestrator])
+
+  const toggleStyleShifts = useCallback(() => {
+    const next = !styleShifts
+    setStyleShiftsLocal(next)
+    reactiveBehaviors?.setStyleShiftsEnabled(next)
+  }, [styleShifts, reactiveBehaviors])
+
+  const commitBpm = useCallback(() => {
+    const v = parseInt(bpmInput)
+    if (v >= 40 && v <= 220) {
+      orchestrator?.setBpm(v)
+      // Also sync the studio store BPM
+      useStudioStore.getState().setBpm(v)
+    }
+    setBpmInput('')
+  }, [bpmInput, orchestrator])
 
   const lyricsEndRef = useRef<HTMLDivElement>(null)
-  const [showReport, setShowReport] = useState(false)
   const [shareCaption, setShareCaption] = useState('')
   const [shareConfirmed, setShareConfirmed] = useState(false)
   const [triggerPresetId, setTriggerPresetId] = useState<string>(
@@ -168,7 +324,6 @@ export function OrganismCommandCenter() {
   const currentBpm = isRunning && physicsState?.pulse
     ? Math.round(physicsState.pulse)
     : (activePreset?.bpm ?? null)
-  const currentMode = physicsState?.mode ?? activePreset?.mode
   const countingIn = countInBeat !== null
 
   const ostate = organismState?.current
@@ -183,9 +338,6 @@ export function OrganismCommandCenter() {
     lyricsEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [transcription?.lines.length])
 
-  useEffect(() => {
-    if (!isRunning && lastReport) setShowReport(true)
-  }, [isRunning, lastReport])
 
   // ── Section helpers ──────────────────────────────────────────────────────
 
@@ -336,37 +488,90 @@ export function OrganismCommandCenter() {
           overflow: 'hidden',
         }}>
 
-          {/* Voice command placeholder */}
+          {/* Voice command */}
           <div style={{
             padding: '12px 14px 10px',
             borderBottom: `0.5px solid ${C.border}`,
             flexShrink: 0,
           }}>
-            <div style={{ ...label11, marginBottom: 8 }}>Vibe Command</div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <span style={{ ...label11 }}>Vibe Command</span>
+              {!hasSpeechRecognition && (
+                <span style={{ fontSize: 9, color: C.text3 }}>Chrome only</span>
+              )}
+            </div>
             <div style={{
-              display: 'flex', alignItems: 'center', gap: 8,
+              display: 'flex', flexDirection: 'column', gap: 6,
               padding: '8px 10px',
               borderRadius: 8,
-              border: `0.5px solid ${C.border2}`,
-              background: C.bg2,
-              opacity: 0.6,
+              border: isListening
+                ? `0.5px solid rgba(34,211,238,0.5)`
+                : `0.5px solid ${C.border2}`,
+              background: isListening ? 'rgba(34,211,238,0.04)' : C.bg2,
+              transition: 'all 0.2s',
             }}>
-              <button
-                disabled
-                title="Voice command — coming soon"
-                style={{
-                  width: 30, height: 30, borderRadius: '50%', flexShrink: 0,
-                  background: 'rgba(34,211,238,0.08)',
-                  border: '1px solid rgba(34,211,238,0.2)',
-                  color: C.cyan, fontSize: 14, cursor: 'not-allowed',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                }}
-              >
-                🎤
-              </button>
-              <span style={{ fontSize: 12, color: C.text3, fontStyle: 'italic' }}>
-                "dark trap beat like Kendrick…" — coming soon
-              </span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <button
+                  onClick={toggleListening}
+                  disabled={!hasSpeechRecognition}
+                  title={
+                    !hasSpeechRecognition ? 'Speech recognition requires Chrome'
+                    : isListening ? 'Stop listening'
+                    : 'Say your vibe (e.g. "dark drill beat like Kendrick")'
+                  }
+                  style={{
+                    width: 30, height: 30, borderRadius: '50%', flexShrink: 0,
+                    background: isListening
+                      ? 'rgba(34,211,238,0.20)'
+                      : 'rgba(34,211,238,0.08)',
+                    border: isListening
+                      ? '1px solid rgba(34,211,238,0.60)'
+                      : '1px solid rgba(34,211,238,0.20)',
+                    color: C.cyan, fontSize: 14,
+                    cursor: hasSpeechRecognition ? 'pointer' : 'not-allowed',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    animation: isListening ? 'pulse 1s ease-in-out infinite' : 'none',
+                    opacity: hasSpeechRecognition ? 1 : 0.5,
+                  }}
+                >
+                  🎤
+                </button>
+                <span style={{
+                  fontSize: 12,
+                  color: isListening ? C.cyan : (vibeText ? C.text : C.text3),
+                  fontStyle: (isListening || vibeText) ? 'normal' : 'italic',
+                  flex: 1, minWidth: 0,
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                  {isListening
+                    ? (vibeText || 'Listening…')
+                    : vibeStatus === 'interpreting'
+                    ? 'Interpreting…'
+                    : (vibeText || '"dark drill beat like Kendrick…"')
+                  }
+                </span>
+                {vibeText && !isListening && vibeStatus !== 'interpreting' && (
+                  <button
+                    onClick={() => { setVibeText(''); setVibeStatus('idle') }}
+                    style={{
+                      fontSize: 10, color: C.text3, background: 'transparent',
+                      border: 'none', cursor: 'pointer', flexShrink: 0, padding: 2,
+                    }}
+                    title="Clear"
+                  >✕</button>
+                )}
+              </div>
+              {/* Interpretation result */}
+              {vibeStatus === 'interpreting' && (
+                <div style={{ fontSize: 10, color: C.amber, paddingLeft: 38, fontWeight: 500 }}>
+                  Interpreting…
+                </div>
+              )}
+              {vibeInterpretation && vibeStatus === 'done' && (
+                <div style={{ fontSize: 10, color: C.green, paddingLeft: 38, fontWeight: 500 }}>
+                  ✓ {vibeInterpretation.result}
+                </div>
+              )}
             </div>
           </div>
 
@@ -529,11 +734,69 @@ export function OrganismCommandCenter() {
           </div>
         </div>
 
-        {/* ── RIGHT: Beat shape + feature toggles + session sidebar ────── */}
+        {/* ── RIGHT: controls ─────────────────────────────────────────── */}
         <div style={{
           display: 'flex', flexDirection: 'column',
           overflow: 'hidden',
         }}>
+
+          {/* ── Pinned transport bar — always visible ─────────────────── */}
+          <div style={{
+            padding: '8px 14px',
+            borderBottom: `0.5px solid ${C.border}`,
+            flexShrink: 0,
+            display: 'flex', alignItems: 'center', gap: 8,
+          }}>
+            {/* Flow meter inline */}
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <FlowMeter depth={flowDepth} />
+            </div>
+            {/* Transport buttons */}
+            <div style={{ display: 'flex', gap: 5, flexShrink: 0 }}>
+              {!isRunning ? (
+                <button
+                  onClick={() => swapPreset(activePresetId ?? quickStartPresets[0]?.id ?? '')}
+                  style={{
+                    padding: '5px 14px', borderRadius: 6, fontSize: 12, fontWeight: 700,
+                    background: '#166534', color: C.green,
+                    border: '1px solid rgba(34,197,94,0.3)', cursor: 'pointer',
+                  }}
+                >▶ Start</button>
+              ) : (
+                <button
+                  onClick={stop}
+                  style={{
+                    padding: '5px 14px', borderRadius: 6, fontSize: 12, fontWeight: 700,
+                    background: 'rgba(239,68,68,0.15)', color: C.red,
+                    border: '1px solid rgba(239,68,68,0.3)', cursor: 'pointer',
+                  }}
+                >⏹ Stop</button>
+              )}
+              <button
+                onClick={isRecording ? () => stopRecording() : () => startRecording()}
+                style={{
+                  padding: '5px 10px', borderRadius: 6, fontSize: 11, fontWeight: 600,
+                  background: isRecording ? 'rgba(239,68,68,0.15)' : 'transparent',
+                  color: isRecording ? C.red : C.text2,
+                  border: isRecording ? '1px solid rgba(239,68,68,0.4)' : `1px solid ${C.border2}`,
+                  cursor: 'pointer',
+                  animation: isRecording ? 'pulse 1.5s ease-in-out infinite' : 'none',
+                }}
+              >{isRecording ? '⏺ REC' : '⏺ REC'}</button>
+              <button
+                onClick={() => capture()}
+                style={{
+                  padding: '5px 8px', borderRadius: 6, fontSize: 11, fontWeight: 600,
+                  background: 'transparent', color: C.text2,
+                  border: `1px solid ${C.border2}`, cursor: 'pointer',
+                }}
+                title="Capture session DNA"
+              >💾</button>
+            </div>
+          </div>
+
+          {/* ── Scrollable sections ───────────────────────────────────── */}
+          <div style={{ flex: 1, overflowY: 'auto' }}>
 
           {/* Beat shape: tweak sliders */}
           <div style={{
@@ -547,6 +810,187 @@ export function OrganismCommandCenter() {
               <SliderRow label="Kick vel."    value={kickVelocity} onChange={setKickVelocity} color='#f472b6' />
               <SliderRow label="Bass vol."    value={bassVolume}   onChange={setBassVolume}   color={C.green} />
               <SliderRow label="Melody vol."  value={melodyVolume} onChange={setMelodyVolume} color='#38bdf8' />
+            </div>
+          </div>
+
+          {/* Organism Mode + BPM */}
+          <div style={{
+            padding: '10px 14px 8px',
+            borderBottom: `0.5px solid ${C.border}`,
+            flexShrink: 0,
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <span style={{ ...label11 }}>Mode</span>
+              {/* BPM manual input */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <span style={{ fontSize: 10, color: C.text3 }}>BPM</span>
+                <input
+                  type="number" min={40} max={220}
+                  value={bpmInput || (physicsState?.pulse ? Math.round(physicsState.pulse) : (activePreset?.bpm ?? ''))}
+                  onChange={e => setBpmInput(e.target.value)}
+                  onBlur={commitBpm}
+                  onKeyDown={e => { if (e.key === 'Enter') commitBpm() }}
+                  style={{
+                    width: 52, height: 24, borderRadius: 5, textAlign: 'center',
+                    border: `0.5px solid ${C.border2}`, background: C.bg2,
+                    color: C.text, fontSize: 11, fontWeight: 700,
+                    outline: 'none',
+                  }}
+                />
+              </div>
+            </div>
+            {/* Mode buttons — Heat / Ice / Smoke / Gravel / Glow + Auto */}
+            {(() => {
+              const MODES = [
+                { key: 'heat',   label: 'Heat',   color: '#f87171' },
+                { key: 'ice',    label: 'Ice',    color: '#93c5fd' },
+                { key: 'smoke',  label: 'Smoke',  color: '#d1d5db' },
+                { key: 'gravel', label: 'Gravel', color: '#fbbf24' },
+                { key: 'glow',   label: 'Glow',   color: '#6ee7b7' },
+              ]
+              const currentMode = (physicsState?.mode as string) ?? lockedMode
+              return (
+                <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                  {MODES.map(m => {
+                    const active = currentMode === m.key
+                    return (
+                      <button
+                        key={m.key}
+                        onClick={() => applyMode(m.key)}
+                        style={{
+                          padding: '3px 9px', borderRadius: 999, fontSize: 10, fontWeight: 600,
+                          cursor: 'pointer',
+                          border: active ? `1px solid ${m.color}55` : `1px solid rgba(100,116,139,0.2)`,
+                          background: active ? `${m.color}18` : 'transparent',
+                          color: active ? m.color : C.text3,
+                          transition: 'all 0.15s',
+                        }}
+                      >{m.label}</button>
+                    )
+                  })}
+                  <button
+                    onClick={() => applyMode(null)}
+                    style={{
+                      padding: '3px 9px', borderRadius: 999, fontSize: 10, fontWeight: 600,
+                      cursor: 'pointer',
+                      border: lockedMode === null ? `1px solid ${C.cyan}55` : `1px solid rgba(100,116,139,0.2)`,
+                      background: lockedMode === null ? `${C.cyan}18` : 'transparent',
+                      color: lockedMode === null ? C.cyan : C.text3,
+                      transition: 'all 0.15s',
+                    }}
+                  >Auto</button>
+                </div>
+              )
+            })()}
+          </div>
+
+          {/* Playing Style: chord technique + articulations + style shifts */}
+          <div style={{
+            padding: '10px 14px 8px',
+            borderBottom: `0.5px solid ${C.border}`,
+            flexShrink: 0,
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <span style={{ ...label11 }}>Playing Style</span>
+              {/* Style Shifts toggle */}
+              <button
+                onClick={toggleStyleShifts}
+                style={{
+                  padding: '2px 8px', borderRadius: 999, fontSize: 9, fontWeight: 600,
+                  cursor: 'pointer',
+                  border: styleShifts ? `1px solid ${C.green}55` : `1px solid rgba(100,116,139,0.2)`,
+                  background: styleShifts ? `${C.green}18` : 'transparent',
+                  color: styleShifts ? C.green : C.text3,
+                  letterSpacing: '0.05em',
+                }}
+                title="Auto style-shifts — reactive engine adapts technique based on rapper energy"
+              >
+                {styleShifts ? 'AUTO SHIFTS' : 'MANUAL'}
+              </button>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {/* Chord technique */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 10, color: C.text3, width: 62, flexShrink: 0 }}>Chords</span>
+                <select
+                  value={chordTech}
+                  onChange={e => applyChordTech(e.target.value)}
+                  style={{
+                    flex: 1, height: 26, borderRadius: 5, fontSize: 10,
+                    border: `0.5px solid ${C.border2}`, background: C.bg2,
+                    color: C.text, paddingLeft: 6, outline: 'none',
+                  }}
+                >
+                  <optgroup label="Piano">
+                    <option value="piano-block-chord">Block Chord</option>
+                    <option value="piano-rolled-chord">Rolled Chord</option>
+                    <option value="piano-alberti">Alberti 1-5-3-5</option>
+                    <option value="piano-sustained-pad">Sustained Pad</option>
+                  </optgroup>
+                  <optgroup label="Guitar">
+                    <option value="guitar-strum-down">Strum Down</option>
+                    <option value="guitar-strum-up">Strum Up</option>
+                    <option value="guitar-arp-rolled">Arpeggio Rolled</option>
+                    <option value="guitar-muted-stab">Muted Stab</option>
+                  </optgroup>
+                  <optgroup label="Strings">
+                    <option value="strings-pizzicato">Strings Pizzicato</option>
+                    <option value="strings-legato">Strings Legato</option>
+                    <option value="strings-tremolo">Tremolo</option>
+                    <option value="strings-staccato">Staccato</option>
+                  </optgroup>
+                  <optgroup label="Brass">
+                    <option value="brass-stab">Brass Stab</option>
+                    <option value="brass-swell">Swell</option>
+                    <option value="brass-fanfare">Fanfare</option>
+                    <option value="brass-section-pad">Section Pad</option>
+                  </optgroup>
+                  <optgroup label="Wind">
+                    <option value="wind-legato">Wind Legato</option>
+                    <option value="wind-run">Scalar Run</option>
+                    <option value="wind-staccato">Wind Staccato</option>
+                    <option value="wind-trill">Trill</option>
+                  </optgroup>
+                </select>
+              </div>
+              {/* Melody articulation */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 10, color: C.text3, width: 62, flexShrink: 0 }}>Melody</span>
+                <select
+                  value={melodyArt}
+                  onChange={e => applyMelodyArt(e.target.value)}
+                  style={{
+                    flex: 1, height: 26, borderRadius: 5, fontSize: 10,
+                    border: `0.5px solid ${C.border2}`, background: C.bg2,
+                    color: C.text, paddingLeft: 6, outline: 'none',
+                  }}
+                >
+                  <option value="none">Straight</option>
+                  <option value="legato-slur">Legato Slur</option>
+                  <option value="staccato-pop">Staccato Pop</option>
+                  <option value="grace-flick">Grace-Note Flick</option>
+                  <option value="trill-ornament">Trill Ornament</option>
+                </select>
+              </div>
+              {/* Bass articulation */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 10, color: C.text3, width: 62, flexShrink: 0 }}>Bass</span>
+                <select
+                  value={bassArt}
+                  onChange={e => applyBassArt(e.target.value)}
+                  style={{
+                    flex: 1, height: 26, borderRadius: 5, fontSize: 10,
+                    border: `0.5px solid ${C.border2}`, background: C.bg2,
+                    color: C.text, paddingLeft: 6, outline: 'none',
+                  }}
+                >
+                  <option value="none">Straight</option>
+                  <option value="bass-slide-up">Slide-Up</option>
+                  <option value="bass-ghost-note">Ghost Note</option>
+                  <option value="bass-octave-jump">Octave Jump</option>
+                  <option value="bass-walking-step">Walking Step</option>
+                </select>
+              </div>
             </div>
           </div>
 
@@ -581,70 +1025,8 @@ export function OrganismCommandCenter() {
             </div>
           </div>
 
-          {/* Session: flow meter + controls */}
-          <div style={{
-            padding: '10px 14px 8px',
-            borderBottom: `0.5px solid ${C.border}`,
-            flexShrink: 0,
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 10 }}>
-              <FlowMeter depth={flowDepth} />
-            </div>
-
-            {/* Main transport buttons */}
-            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-              {!isRunning ? (
-                <button
-                  onClick={() => swapPreset(activePresetId ?? quickStartPresets[0]?.id ?? '')}
-                  style={{
-                    padding: '6px 16px', borderRadius: 6, fontSize: 12, fontWeight: 700,
-                    background: '#166534', color: C.green,
-                    border: '1px solid rgba(34,197,94,0.3)', cursor: 'pointer',
-                  }}
-                >
-                  ▶ Start
-                </button>
-              ) : (
-                <button
-                  onClick={stop}
-                  style={{
-                    padding: '6px 16px', borderRadius: 6, fontSize: 12, fontWeight: 700,
-                    background: 'rgba(239,68,68,0.15)', color: C.red,
-                    border: '1px solid rgba(239,68,68,0.3)', cursor: 'pointer',
-                  }}
-                >
-                  ⏹ Stop
-                </button>
-              )}
-              <button
-                onClick={isRecording ? () => stopRecording() : () => startRecording()}
-                style={{
-                  padding: '6px 12px', borderRadius: 6, fontSize: 12, fontWeight: 600,
-                  background: isRecording ? 'rgba(239,68,68,0.15)' : 'transparent',
-                  color: isRecording ? C.red : C.text2,
-                  border: isRecording ? '1px solid rgba(239,68,68,0.4)' : `1px solid ${C.border2}`,
-                  cursor: 'pointer',
-                  animation: isRecording ? 'pulse 1.5s ease-in-out infinite' : 'none',
-                }}
-              >
-                {isRecording ? '⏺ Recording…' : '⏺ Record'}
-              </button>
-              <button
-                onClick={() => capture()}
-                style={{
-                  padding: '6px 12px', borderRadius: 6, fontSize: 12, fontWeight: 600,
-                  background: 'transparent', color: C.text2,
-                  border: `1px solid ${C.border2}`, cursor: 'pointer',
-                }}
-                title="Capture session DNA"
-              >
-                💾 Save
-              </button>
-            </div>
-          </div>
-
-          {/* Scrollable bottom: lyrics + report card + share */}
-          <div style={{ flex: 1, overflow: 'auto', padding: '10px 14px' }}>
+          {/* Lyrics + report card + share */}
+          <div style={{ padding: '10px 14px' }}>
 
             {/* Error */}
             {error && (
@@ -834,6 +1216,8 @@ export function OrganismCommandCenter() {
             )}
 
           </div>
+
+          </div>{/* end scrollable sections */}
         </div>
       </div>
     </div>

--- a/client/src/features/organism/OrganismContext.tsx
+++ b/client/src/features/organism/OrganismContext.tsx
@@ -166,6 +166,12 @@ export interface OrganismContextValue {
   performerState:   PerformerState   | null
   /** Periodic self-analysis of Astutely's own audio output. */
   selfListenReport: SelfListenReport | null
+
+  // Natural Language Vibe Interpreter
+  /** Interpret a free-text vibe description and apply it to the organism. */
+  interpretVibe:      (text: string) => Promise<void>
+  /** Last interpretation result — null until first voice command. */
+  vibeInterpretation: { text: string; result: string; confidence: number } | null
 }
 
 const OrganismContext = createContext<OrganismContextValue | null>(null)

--- a/client/src/features/organism/OrganismProvider.tsx
+++ b/client/src/features/organism/OrganismProvider.tsx
@@ -18,6 +18,7 @@ import { AutoGenerateSource }    from '../../organism/input/AutoGenerateSource'
 import type { InputSource, InputSourceType } from '../../organism/input/types'
 
 import { OrganismMode, type PhysicsState } from '../../organism/physics/types'
+import type { HipHopSubGenre } from '../../organism/state/MusicalState'
 import type { OrganismState }   from '../../organism/state/types'
 import type { MixMeterReading } from '../../organism/mix/types'
 import type { SessionDNA }      from '../../organism/session/types'
@@ -49,6 +50,7 @@ import { useStudioStore } from '../../stores/useStudioStore'
 import type { MusicalKey, KeyMode } from '../../stores/useStudioStore'
 import { bridgeOrganismToStore } from '../../stores/organismToStudioBridge'
 import { orgLog, orgPhase, startOrgHeartbeat } from '../../lib/perf/organismLog'
+import { interpretVibeRuleBased, type VibeParams } from './ArtistReferenceBank'
 
 interface Props {
   children:  React.ReactNode
@@ -188,6 +190,7 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
   const [bassVolume,       setBassVolumeState]  = useState(1)
   const [melodyVolume,     setMelodyVolumeState]= useState(1)
   const [textureEnabled,   setTextureEnabledState] = useState(false)  // off by default for hip-hop
+  const [vibeInterpretation, setVibeInterpretation] = useState<{ text: string; result: string; confidence: number } | null>(null)
 
   // Recording state — captures beat audio + vocal audio + MIDI + lyrics
   const [isRecording,      setIsRecording]      = useState(false)
@@ -301,7 +304,6 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
 
     // Bridge chord changes to external listeners (Astutely, UI)
     const unsubChord = orchestr.onChordChange((chord, rootPitchClass) => {
-      const progression = orchestr.getCurrentChord()
       window.dispatchEvent(new CustomEvent('organism:chord-change', {
         detail: {
           currentChord: chord,
@@ -583,6 +585,35 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
       await orchestrRef.current.start()
       primeAutoGenerateStart()
       setIsRunning(true)
+
+      // Fast-boot: skip the Dormant wait, start playing immediately from bar 1.
+      // Set a floor of Breathing so a quiet mic can't regress to Dormant mid-session.
+      if (stateMachRef.current && physicsRef.current) {
+        const fallbackPulse = 90
+        const fallbackBeatMs = 60000 / fallbackPulse
+        const fallbackSixteenthMs = fallbackBeatMs / 4
+        const fallbackPhysics: PhysicsState = {
+          mode: OrganismMode.Glow,
+          pulse: fallbackPulse,
+          bounce: 0.5,
+          swing: 0.5,
+          pocket: 0.5,
+          presence: 0.4,
+          density: 0.4,
+          beatDurationMs: fallbackBeatMs,
+          sixteenthDurationMs: fallbackSixteenthMs,
+          swungSixteenthMs: fallbackSixteenthMs,
+          timestamp: Date.now(),
+          frameIndex: 0,
+          voiceActive: false,
+        }
+        const seedPhysics = physicsRef.current.getLastState() ?? fallbackPhysics
+        stateMachRef.current.forceState(OState.Awakening, seedPhysics)
+        stateMachRef.current.forceState(OState.Breathing, seedPhysics)
+        stateMachRef.current.setStateFloor(OState.Breathing)
+        orchestrRef.current.regenerateAll()
+      }
+
       // Start self-listen after audio is running
       selfListenRef.current?.start()
       if (transcriptionEnabled && transcriberRef.current) {
@@ -603,6 +634,8 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
     inputRef.current?.stop()
     orchestrRef.current?.stop()
     transcriberRef.current?.stop()
+    // Clear state floor so the machine fully resets on the next start()
+    stateMachRef.current?.setStateFloor(null)
     setIsRunning(false)
     orgLog('provider:stopped', { inputSource, bpm })
 
@@ -831,6 +864,83 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
     orchestr.regenerateAll()
     setActivePresetId(presetId)
     endSwap({ presetId, bpm: preset.bpm, mode: preset.mode })
+  }, [quickStart])
+
+  /**
+   * Natural Language Vibe Interpreter
+   *
+   * Takes a free-text description ("dark drill beat like Kendrick, fired up")
+   * and applies matching beat parameters to the live organism.
+   *
+   * Resolution order:
+   *   1. /api/organism/interpret-vibe (Ollama → Grok AI)
+   *   2. ArtistReferenceBank.interpretVibeRuleBased (rule-based fallback)
+   *
+   * If the organism isn't running, it cold-starts on the closest preset
+   * and then overrides with the interpreted params.
+   */
+  const interpretVibe = useCallback(async (text: string) => {
+    let params: VibeParams | null = null
+
+    // 1. Try server AI (Ollama → Grok fallback).
+    // 4s timeout via AbortController — Ollama can hang on cold model load,
+    // and we'd rather drop to the instant rule-based path than freeze the UI.
+    const controller = new AbortController()
+    const timeoutId  = setTimeout(() => controller.abort(), 4000)
+    try {
+      const res = await fetch('/api/organism/interpret-vibe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+        signal: controller.signal,
+      })
+      if (res.ok) {
+        params = await res.json() as VibeParams
+        orgLog('interpretVibe:ai', { text: text.slice(0, 60), interpretation: params.interpretation })
+      }
+    } catch {
+      // Network error, abort, or timeout — fall through to rule-based
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    // 2. Rule-based fallback
+    if (!params) {
+      params = interpretVibeRuleBased(text)
+      orgLog('interpretVibe:ruleBased', { text: text.slice(0, 60), interpretation: params.interpretation })
+    }
+
+    // Update UI state so CommandCenter can show what was understood
+    setVibeInterpretation({
+      text,
+      result: params.interpretation,
+      confidence: params.confidence,
+    })
+
+    // Hot path: apply params to the running organism
+    const mode = params.mode as OrganismMode
+
+    // Cold start if not already running — pick closest preset by mode, then override
+    if (!isRunningRef.current) {
+      const closestPreset = QUICK_START_PRESETS.find(p => p.mode === mode) ?? QUICK_START_PRESETS[0]
+      await quickStart(closestPreset.id)
+      // Give quickStart a tick to complete before overriding
+      await new Promise<void>(resolve => setTimeout(resolve, 120))
+    }
+
+    const physics = physicsRef.current
+    const orchestr = orchestrRef.current
+    if (physics && orchestr) {
+      physics.lockMode(mode)
+      orchestr.setBpm(params.bpm)
+      useStudioStore.getState().setBpm(params.bpm)
+      orchestr.forceSubGenre(params.subGenre as HipHopSubGenre)
+      orchestr.regenerateAll()
+      orgLog('interpretVibe:applied', {
+        bpm: params.bpm, mode, subGenre: params.subGenre,
+        confidence: params.confidence,
+      })
+    }
   }, [quickStart])
 
   /**
@@ -1347,7 +1457,7 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
         const { mood } = action
         // Force sub-genre if the phrase strongly implies one
         if (mood.preferredSubGenre) {
-          orch.forceSubGenre(mood.preferredSubGenre as any)
+          orch.forceSubGenre(mood.preferredSubGenre as HipHopSubGenre)
         }
         // Nudge energy via volume multipliers based on intent
         switch (mood.intent) {
@@ -2119,6 +2229,10 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
     // Ears system
     performerState,
     selfListenReport,
+
+    // Natural Language Vibe Interpreter
+    interpretVibe,
+    vibeInterpretation,
   }), [
     lastSessionDNA,
     start, stop, captureSession, downloadMidi,
@@ -2140,6 +2254,7 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
     shareSession, isSharingSession, lastSharedPostUrl,
     isRunning, isCapturing, error,
     performerState, selfListenReport,
+    interpretVibe, vibeInterpretation,
   ])
 
   return (

--- a/client/src/features/organism/__tests__/ArtistReferenceBank.test.ts
+++ b/client/src/features/organism/__tests__/ArtistReferenceBank.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+import { interpretVibeRuleBased } from '../ArtistReferenceBank'
+
+describe('interpretVibeRuleBased — artist references', () => {
+  // Each entry is a single representative key; the bank has aliases for most.
+  const ARTIST_CASES: Array<[string, string, number, number]> = [
+    // [input, expected mode, expected bpm, min confidence]
+    ['tupac',          'gravel', 90,  0.9],
+    ['eminem',         'heat',   105, 0.9],
+    ['drake',          'glow',   80,  0.9],
+    ['kendrick',       'gravel', 88,  0.9],
+    ['travis scott',   'ice',    140, 0.9],
+    ['j cole',         'glow',   85,  0.85],
+    ['future',         'ice',    130, 0.85],
+    ['nas',            'gravel', 92,  0.85],
+    ['21 savage',      'heat',   140, 0.85],
+    ['pop smoke',      'gravel', 140, 0.85],
+    ['chief keef',     'gravel', 145, 0.85],
+    ['gunna',          'ice',    142, 0.85],
+    ['lil baby',       'heat',   142, 0.85],
+    ['polo g',         'ice',    138, 0.85],
+    ['rod wave',       'glow',   80,  0.85],
+    ['playboi carti',  'ice',    140, 0.85],
+  ]
+
+  it.each(ARTIST_CASES)(
+    'resolves %q to mode=%s bpm=%d',
+    (input, expectedMode, expectedBpm, minConfidence) => {
+      const result = interpretVibeRuleBased(input)
+      expect(result.mode).toBe(expectedMode)
+      expect(result.bpm).toBe(expectedBpm)
+      expect(result.confidence).toBeGreaterThanOrEqual(minConfidence)
+      expect(result.interpretation).toBeTypeOf('string')
+      expect(result.interpretation.length).toBeGreaterThan(0)
+    }
+  )
+
+  it('normalizes multi-word artist keys across punctuation', () => {
+    // These should all hit the Travis Scott entry even with surrounding noise.
+    expect(interpretVibeRuleBased('travis scott, trap vibes').subGenre).toBe('trap')
+    expect(interpretVibeRuleBased('la flame!!').mode).toBe('ice')
+    expect(interpretVibeRuleBased('CACTUS JACK beat').bpm).toBe(140)
+  })
+
+  it('treats artist matches as higher priority than generic genre keywords', () => {
+    // "Kendrick" says boom-bap, but the phrase also contains "trap" which would
+    // otherwise match a genre entry. Artist should win (it's first in the scan order).
+    const result = interpretVibeRuleBased('kendrick trap')
+    expect(result.subGenre).toBe('boom-bap')
+    expect(result.mode).toBe('gravel')
+  })
+})
+
+describe('interpretVibeRuleBased — genre keywords', () => {
+  it('matches uk drill specifically before falling through to plain drill', () => {
+    const uk = interpretVibeRuleBased('uk drill')
+    expect(uk.bpm).toBe(140)
+    expect(uk.subGenre).toBe('drill')
+  })
+
+  it('matches chicago drill before plain drill', () => {
+    const chi = interpretVibeRuleBased('chicago drill vibes')
+    expect(chi.bpm).toBe(145)
+    expect(chi.energy).toBeGreaterThanOrEqual(0.9)
+  })
+
+  it('falls through to plain drill for bare keyword', () => {
+    const plain = interpretVibeRuleBased('drill')
+    expect(plain.subGenre).toBe('drill')
+    expect(plain.bpm).toBe(145)
+  })
+
+  it('matches boom-bap with hyphen, without hyphen, and with space', () => {
+    expect(interpretVibeRuleBased('boom-bap').subGenre).toBe('boom-bap')
+    expect(interpretVibeRuleBased('boom bap').subGenre).toBe('boom-bap')
+  })
+
+  it('matches lo-fi under multiple spellings', () => {
+    expect(interpretVibeRuleBased('lofi').subGenre).toBe('lo-fi')
+    expect(interpretVibeRuleBased('lo-fi').subGenre).toBe('lo-fi')
+    expect(interpretVibeRuleBased('lo fi').subGenre).toBe('lo-fi')
+  })
+
+  it('uses chill as the glow/low-energy genre', () => {
+    const r = interpretVibeRuleBased('just chill')
+    expect(r.subGenre).toBe('chill')
+    expect(r.mode).toBe('glow')
+    expect(r.energy).toBeLessThan(0.5)
+  })
+})
+
+describe('interpretVibeRuleBased — mood modifiers', () => {
+  it('"dark" shifts mode to gravel and lowers energy', () => {
+    const base = interpretVibeRuleBased('trap')
+    const dark = interpretVibeRuleBased('dark trap')
+    expect(dark.mode).toBe('gravel')
+    expect(dark.energy).toBeLessThan(base.energy)
+  })
+
+  it('"fired up" raises energy, density, and bounce', () => {
+    const base = interpretVibeRuleBased('trap')
+    const hype = interpretVibeRuleBased('fired up trap')
+    expect(hype.energy).toBeGreaterThan(base.energy)
+    expect(hype.density).toBeGreaterThan(base.density)
+    expect(hype.bounce).toBeGreaterThan(base.bounce)
+  })
+
+  it('"story beat" slows tempo and reduces density', () => {
+    const base = interpretVibeRuleBased('boom bap')
+    const story = interpretVibeRuleBased('boom bap story beat')
+    expect(story.bpm).toBe(base.bpm - 15)
+    expect(story.density).toBeLessThan(base.density)
+  })
+
+  it('"faster" adds 20 BPM, "slower" subtracts 20', () => {
+    const base = interpretVibeRuleBased('trap')
+    expect(interpretVibeRuleBased('faster trap').bpm).toBe(base.bpm + 20)
+    expect(interpretVibeRuleBased('slower trap').bpm).toBe(base.bpm - 20)
+  })
+
+  it('stacks multiple modifiers on one phrase', () => {
+    const base = interpretVibeRuleBased('trap')
+    const stacked = interpretVibeRuleBased('fired up aggressive trap')
+    // Both 'fired up' (+0.15) and 'aggressive' (+0.20) raise energy.
+    expect(stacked.energy).toBeGreaterThan(base.energy + 0.20)
+  })
+
+  it('"soulful" overrides mode to smoke and boosts swing', () => {
+    const base = interpretVibeRuleBased('boom bap')
+    const soulful = interpretVibeRuleBased('soulful boom bap')
+    expect(soulful.mode).toBe('smoke')
+    expect(soulful.swing).toBeGreaterThan(base.swing)
+  })
+})
+
+describe('interpretVibeRuleBased — clamping and edge cases', () => {
+  it('clamps BPM into [60, 200] even with extreme modifiers', () => {
+    // lo-fi base 78, "slower" -20 = 58, would clamp to 60
+    const slowed = interpretVibeRuleBased('slower slower lofi')
+    expect(slowed.bpm).toBeGreaterThanOrEqual(60)
+    expect(slowed.bpm).toBeLessThanOrEqual(200)
+  })
+
+  it('clamps energy/swing/bounce/density into [0, 1]', () => {
+    // Pile on energy-raising modifiers — should cap at 1.0, not overshoot.
+    const maxed = interpretVibeRuleBased('fired up aggressive hard punchy drill')
+    expect(maxed.energy).toBeLessThanOrEqual(1.0)
+    expect(maxed.density).toBeLessThanOrEqual(1.0)
+    expect(maxed.bounce).toBeLessThanOrEqual(1.0)
+
+    // Stack subtractive ones — should floor at 0, not negative.
+    const mellowed = interpretVibeRuleBased('chill smooth story beat')
+    expect(mellowed.energy).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns a valid default for completely unrecognized text', () => {
+    const result = interpretVibeRuleBased('asdfghjkl qwertyuiop')
+    expect(result.bpm).toBeGreaterThanOrEqual(60)
+    expect(result.bpm).toBeLessThanOrEqual(200)
+    expect(['heat', 'ice', 'smoke', 'gravel', 'glow']).toContain(result.mode)
+    expect(result.confidence).toBeGreaterThanOrEqual(0)
+    expect(result.confidence).toBeLessThanOrEqual(1)
+  })
+
+  it('is case-insensitive', () => {
+    const lower = interpretVibeRuleBased('kendrick')
+    const upper = interpretVibeRuleBased('KENDRICK')
+    const mixed = interpretVibeRuleBased('KenDricK')
+    expect(upper).toEqual(lower)
+    expect(mixed).toEqual(lower)
+  })
+
+  it('ignores non-alphanumeric punctuation in matching', () => {
+    // Commas, exclamations, quotes should not block keyword detection.
+    const clean   = interpretVibeRuleBased('drake')
+    const punched = interpretVibeRuleBased('"drake"!!!')
+    const phrased = interpretVibeRuleBased('like, drake, you know?')
+    expect(punched.mode).toBe(clean.mode)
+    expect(phrased.mode).toBe(clean.mode)
+  })
+
+  it('returns an interpretation string under 100 characters', () => {
+    for (const phrase of ['tupac', 'drill', 'fired up aggressive trap', 'nonsense']) {
+      const result = interpretVibeRuleBased(phrase)
+      expect(result.interpretation.length).toBeLessThanOrEqual(100)
+    }
+  })
+})

--- a/client/src/features/organism/__tests__/OrganismControls.test.tsx
+++ b/client/src/features/organism/__tests__/OrganismControls.test.tsx
@@ -85,6 +85,8 @@ function makeCtx(overrides: Partial<OrganismContextValue> = {}): OrganismContext
     lastSharedPostUrl: null,
     performerState: null,
     selfListenReport: null,
+    interpretVibe: vi.fn().mockResolvedValue(undefined),
+    vibeInterpretation: null,
     ...overrides,
   }
 }

--- a/client/src/features/organism/__tests__/OrganismPage.test.tsx
+++ b/client/src/features/organism/__tests__/OrganismPage.test.tsx
@@ -84,6 +84,8 @@ function makeCtx(overrides: Partial<OrganismContextValue> = {}): OrganismContext
     lastSharedPostUrl: null,
     performerState: null,
     selfListenReport: null,
+    interpretVibe: vi.fn().mockResolvedValue(undefined),
+    vibeInterpretation: null,
     ...overrides,
   }
 }

--- a/client/src/features/organism/__tests__/OrganismProvider.test.tsx
+++ b/client/src/features/organism/__tests__/OrganismProvider.test.tsx
@@ -23,6 +23,8 @@ vi.mock('../../../organism/physics/PhysicsEngine', () => ({
     processFrame = vi.fn()
     getLastState = vi.fn().mockReturnValue(null)
     reset = vi.fn()
+    lockMode = vi.fn()
+    unlockMode = vi.fn()
   },
 }))
 
@@ -31,6 +33,8 @@ vi.mock('../../../organism/state/StateMachine', () => ({
     subscribe = vi.fn().mockReturnValue(noop)
     onTransition = vi.fn().mockReturnValue(noop)
     processFrame = vi.fn()
+    setStateFloor = vi.fn()
+    forceState = vi.fn()
     getCurrentState = vi.fn().mockReturnValue({
       current: 'DORMANT', previous: null,
       framesInState: 0, msInState: 0, barsInState: 0,
@@ -48,6 +52,13 @@ vi.mock('../../../organism/generators/GeneratorOrchestrator', () => ({
     start = vi.fn().mockResolvedValue(undefined)
     stop = vi.fn()
     reset = vi.fn()
+    dispose = vi.fn()
+    setBpm = vi.fn()
+    forceSubGenre = vi.fn()
+    regenerateAll = vi.fn()
+    setArrangementEnabled = vi.fn()
+    isArrangementEnabled = vi.fn().mockReturnValue(true)
+    getMusicalState = vi.fn().mockReturnValue(null)
     onChordChange = vi.fn().mockReturnValue(noop)
     getCurrentChord = vi.fn().mockReturnValue(null)
   },

--- a/client/src/organism/generators/BassGenerator.ts
+++ b/client/src/organism/generators/BassGenerator.ts
@@ -154,7 +154,7 @@ export class BassGenerator extends GeneratorBase {
 
     if (newBehavior !== this.currentBehavior) {
       this.currentBehavior = newBehavior
-      this.rebuildPart(physics)
+      this.rebuildPart()
     }
 
     // Only duck filter if we are using a MonoSynth (samplers bypass the filter entirely)
@@ -181,21 +181,31 @@ export class BassGenerator extends GeneratorBase {
 
     if (to === OState.Awakening) {
       this.stopPart()
-      this.rootMidi        = BassGenerator.ROOT_POOL[Math.floor(Math.random() * BassGenerator.ROOT_POOL.length)]
+      // If chord key is known, stay in key; otherwise pick from pool
+      if (this.chordRootPitchClass !== null) {
+        this.rootMidi = Math.max(33, Math.min(48, 3 * 12 + this.chordRootPitchClass))
+      } else {
+        this.rootMidi = BassGenerator.ROOT_POOL[Math.floor(Math.random() * BassGenerator.ROOT_POOL.length)]
+      }
       this.currentMode     = physics.mode
       setBassSwing(physics.mode.toString())
       this.currentBehavior = getBassBehavior(physics.mode, to)
       this.applyBassPreset()
-      this.rebuildPart(physics)
+      this.rebuildPart()
       return
     }
 
-    this.rootMidi    = BassGenerator.ROOT_POOL[Math.floor(Math.random() * BassGenerator.ROOT_POOL.length)]
+    // If chord key is known, stay in key; otherwise pick from pool
+    if (this.chordRootPitchClass !== null) {
+      this.rootMidi = Math.max(33, Math.min(48, 3 * 12 + this.chordRootPitchClass))
+    } else {
+      this.rootMidi = BassGenerator.ROOT_POOL[Math.floor(Math.random() * BassGenerator.ROOT_POOL.length)]
+    }
     this.currentMode = physics.mode
     setBassSwing(physics.mode.toString()) 
     this.currentBehavior = getBassBehavior(physics.mode, to)
     this.applyBassPreset()
-    this.rebuildPart(physics)
+    this.rebuildPart()
   }
 
   reset(): void {
@@ -282,7 +292,7 @@ export class BassGenerator extends GeneratorBase {
           attack: 0.04, decay: 0.15, sustain: 0.35, release: 0.15,
           baseFrequency: 80, octaves: voice.octaves || 2.0,
         },
-      } as any)
+      } as Partial<Tone.MonoSynthOptions>)
       this.synth.volume.value = voice.volume
       
       // Connect to Filter -> MonoSub -> Distortion -> Compressor chain
@@ -306,6 +316,8 @@ export class BassGenerator extends GeneratorBase {
     if (clamped !== this.rootMidi) {
       this.rootMidi = clamped
       this.chordRootPitchClass = bassPC
+      // Rebuild so the running Tone.Part immediately uses the new root
+      this.rebuildPart()
     }
   }
 
@@ -326,7 +338,7 @@ export class BassGenerator extends GeneratorBase {
   private lastRebuildTime: number = 0
   private static readonly MIN_REBUILD_INTERVAL_MS = 500
 
-  private rebuildPart(_physics: PhysicsState): void {
+  private rebuildPart(): void {
     const now = performance.now()
     if (now - this.lastRebuildTime < BassGenerator.MIN_REBUILD_INTERVAL_MS) return
     this.lastRebuildTime = now
@@ -395,7 +407,7 @@ export class BassGenerator extends GeneratorBase {
     const portTime = getPortamentoTime(this.currentBehavior)
     if (!this.isCurrentVoiceSampler) {
       try {
-        (this.synth as any).portamento = slideActive ? portTime : 0
+        (this.synth as Tone.MonoSynth).portamento = slideActive ? portTime : 0
       } catch { /* */ }
     }
 

--- a/client/src/organism/generators/MelodyGenerator.ts
+++ b/client/src/organism/generators/MelodyGenerator.ts
@@ -410,6 +410,8 @@ export class MelodyGenerator extends GeneratorBase {
   }
 
   setCurrentChord(chord: ChordEvent, rootPitchClass: number): void {
+    // Keep rootPitchClass in sync so buildPhrase generates notes in the right key
+    this.rootPitchClass = rootPitchClass
     this.currentChordTones = getChordTones(chord, rootPitchClass)
     // Dynamic harmonic flow: when chord changes, auto-rebuild phrase to match
     this.scaleDirty = true

--- a/server/src/organism/sessionRouter.ts
+++ b/server/src/organism/sessionRouter.ts
@@ -134,6 +134,83 @@ Step indices 0–15 (16th-note grid, one bar).
   }
 });
 
+// POST /api/organism/interpret-vibe
+// Takes a free-text vibe description ("dark trap beat like Kendrick, fired up drill style")
+// and returns structured beat parameters ready to apply to the organism.
+// Uses Ollama (local/Railway) first, falls back to Grok-3 cloud.
+// Client falls back to ArtistReferenceBank if this endpoint returns 503.
+sessionRouter.post("/interpret-vibe", async (req, res) => {
+  const { text } = req.body as { text?: string }
+  if (!text || typeof text !== "string" || text.trim().length === 0) {
+    return res.status(400).json({ error: "Missing text" })
+  }
+
+  const clampedText = text.trim().slice(0, 300)
+
+  const systemPrompt = `You are a hip-hop beat interpreter for a real-time beat maker. Convert natural language descriptions into beat parameters. Always respond with valid JSON only — no markdown, no explanation.
+
+You understand:
+ARTIST REFERENCES: Tupac (boom-bap, 90 BPM, soulful minor, piano), Eminem (boom-bap, 105 BPM, aggressive, strings), Drake (chill, 80 BPM, piano-pad, smooth), Kendrick (boom-bap, 88 BPM, complex), Travis Scott (trap, 140 BPM, atmospheric synth), J Cole (boom-bap, 85 BPM, warm), Future (trap, 130 BPM, hazy melodic), Nas (boom-bap, 92 BPM, raw lyrical), 21 Savage (trap, 140 BPM, dark minimal), Pop Smoke (drill, 140 BPM, heavy dark), Gunna (trap, 142 BPM, smooth drip), Chief Keef (drill, 145 BPM, menacing), Playboi Carti (trap, 140 BPM, hypnotic), Lil Uzi Vert (trap, 138 BPM, melodic), Rod Wave (melodic, 80 BPM, emotional), Polo G (melodic trap, 140 BPM, introspective).
+
+GENRE TERMS: "drill" → drill/gravel/145 BPM/dark. "trap" → trap/heat/140 BPM. "boom bap" or "boom-bap" → boom-bap/smoke/90 BPM/swingy. "lo-fi" or "lofi" → lo-fi/ice/78 BPM/mellow. "phonk" → phonk/heat/130 BPM/dark. "west coast" → west-coast/gravel/90 BPM/soulful. "dirty south" → dirty-south/smoke/100 BPM.
+
+ENERGY/MOOD SLANG: "fired up", "drip", "fire", "lit", "hard" → high energy. "icy", "cold", "frozen" → mode ice. "raw", "gritty" → mode gravel. "chill", "smooth", "mellow" → low energy glow. "dark" → minor, lower energy, gravel. "punchy" → high bounce/density. "soulful" → swing 0.6+, mode smoke. "story beat", "cinematic" → slower, sparse, breathing room. "aggressive" → energy 0.85+. "melodic" → mode glow, melody forward. "drip" → trap, ice mode.
+
+MODES: heat (trap/drill energy, dark), ice (lo-fi/jazzy, cool), smoke (boom-bap, soulful), gravel (drill/gritty, menacing), glow (chill/warm, melodic).
+SUBGENRES (exact strings to use): boom-bap, trap, drill, lo-fi, west-coast, dirty-south, phonk, jersey-club, bounce, reggaeton, afrobeat, chill`
+
+  const userPrompt = `Interpret this freestyle beat request: "${clampedText}"
+
+Return ONLY this JSON (no markdown, no explanation):
+{"bpm":<60-180>,"mode":<"heat"|"ice"|"smoke"|"gravel"|"glow">,"subGenre":<"boom-bap"|"trap"|"drill"|"lo-fi"|"west-coast"|"dirty-south"|"phonk"|"jersey-club"|"bounce"|"reggaeton"|"afrobeat"|"chill">,"energy":<0.0-1.0>,"swing":<0.0-1.0>,"bounce":<0.0-1.0>,"density":<0.0-1.0>,"interpretation":<"short label like 'Drill — dark, 145 BPM'">,"confidence":<0.0-1.0>}`
+
+  let raw: string | null = null
+
+  try {
+    raw = await localAI.generate(userPrompt, { format: "json", temperature: 0.7 })
+    console.log("[organism:interpret-vibe] Used local AI (Ollama)")
+  } catch {
+    try {
+      const response = await makeAICall(
+        [
+          { role: "system", content: systemPrompt },
+          { role: "user",   content: userPrompt   },
+        ],
+        { response_format: { type: "json_object" }, temperature: 0.7, max_tokens: 300 }
+      )
+      raw = response.choices?.[0]?.message?.content ?? "{}"
+      console.log("[organism:interpret-vibe] Used cloud AI (Grok-3 fallback)")
+    } catch (cloudErr) {
+      console.error("[organism:interpret-vibe] Both AI providers failed:", cloudErr)
+      return res.status(503).json({ error: "AI unavailable — use rule-based fallback" })
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(raw ?? "{}")
+    const VALID_MODES    = ["heat", "ice", "smoke", "gravel", "glow"]
+    const VALID_SUBGENRES = ["boom-bap", "trap", "drill", "lo-fi", "west-coast", "dirty-south", "phonk", "jersey-club", "bounce", "reggaeton", "afrobeat", "chill"]
+
+    const result = {
+      bpm:            Math.max(60, Math.min(200, Number(parsed.bpm)    || 90)),
+      mode:           VALID_MODES.includes(parsed.mode)         ? parsed.mode     : "heat",
+      subGenre:       VALID_SUBGENRES.includes(parsed.subGenre) ? parsed.subGenre : "trap",
+      energy:         Math.max(0, Math.min(1, Number(parsed.energy)  || 0.70)),
+      swing:          Math.max(0, Math.min(1, Number(parsed.swing)   || 0.45)),
+      bounce:         Math.max(0, Math.min(1, Number(parsed.bounce)  || 0.60)),
+      density:        Math.max(0, Math.min(1, Number(parsed.density) || 0.60)),
+      interpretation: typeof parsed.interpretation === "string"
+        ? parsed.interpretation.slice(0, 100)
+        : "Beat interpreted",
+      confidence:     Math.max(0, Math.min(1, Number(parsed.confidence) || 0.70)),
+    }
+    return res.json(result)
+  } catch (parseErr) {
+    console.error("[organism:interpret-vibe] Failed to parse AI JSON:", parseErr, "\nRaw:", raw?.slice(0, 200))
+    return res.status(500).json({ error: "Interpretation failed — invalid AI response" })
+  }
+})
+
 // GET /api/organism/sessions/:userId/:sessionId
 sessionRouter.get("/:userId/:sessionId", async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- **Feature 2 foundation** — natural language → BPM/mode/sub-genre via Ollama → Grok-3 → rule-based fallback
- **Bug fixes** — bass key coherence (chord-aware rebuild), melody root sync on chord change, fast-startup seed that actually matches `PhysicsState`
- **Cleanup pass on Sonnet's WIP** — removed `null as any` workarounds, typed the Web Speech API surface, replaced sub-genre `as any` casts with `HipHopSubGenre`, dropped 10+ dead destructures/unused state

## Why this is a draft
Phase 1 only — tightening the foundation before adding more surface. Deferred to a follow-up PR:
- Extract `VoiceVibeInput.tsx` as its own component
- Voice-commanded instrument swap
- `RealTimeVoiceAdjuster.ts`

## Verification
- `npm run check` — **0 errors**
- `npx eslint` on touched files — **0 errors**, 1 pre-existing `react-hooks/exhaustive-deps` warning on `primeAutoGenerateStart` (predates Sonnet's work, deserves its own PR with runtime testing)
- `npm run test:unit` — **267 passing**, 29 pre-existing TextureGenerator Tone-mock failures unchanged (not grown)
- New tests: 36 cases covering ArtistReferenceBank (artist lookups, genre keywords, mood modifiers, clamping, case-insensitivity, edge cases)

## Commits
- `fix(organism): bass key coherence + melody root sync` — isolated bug fixes, easy to revert
- `feat(organism): natural language vibe interpreter (Feature 2 — Phase 1)` — feature work + fast-startup fix D

## Test plan
- [ ] Start Organism in autoGenerate mode — should seed into Breathing from bar 1 with no Dormant stall
- [ ] Type "boom bap like Dilla" in the vibe input — BPM should land ~90, mode Glow, sub-genre boom-bap
- [ ] Type "trap at 150 like Future" — BPM 150, sub-genre trap
- [ ] Disable network — same prompts should still resolve via rule-based fallback within the 4s timeout
- [ ] Voice input (Chrome/Edge) — click mic, speak a vibe, confirm interim + final transcript paths
- [ ] Regression: play through an existing Quick Start preset, verify no audible key drift on chord changes

## Out of scope (not in this PR)
- `client/src/components/ai/AstutelyChatbot.tsx` has an unrelated working-copy change (removes the "Brain" tab) — left uncommitted on disk for the next session to decide on

🤖 Generated with [Claude Code](https://claude.com/claude-code)