### PR TITLE
feat(organism): producer-quality pass — hat delivery, true parallel comp, 2-bar kicks, groove pocket, key-tuned kick/808

### DIFF
--- a/client/src/organism/generators/DrumGenerator.ts
+++ b/client/src/organism/generators/DrumGenerator.ts
@@ -12,6 +12,7 @@ import {
 }                              from './patterns/DrumPatternLibrary'
 import { getLivePartStart, livePartStartOffset, msUntilTransportTime, quantizeGridTime } from './CompositionClock'
 import { SampledDrumKit }       from './SampledDrumKit'
+import { mulberry32, hashString } from './freeplay/utils'
 import type { PhysicsState }   from '../physics/types'
 import { OrganismMode }        from '../physics/types'
 import type { OrganismState }  from '../state/types'
@@ -188,6 +189,8 @@ export class DrumGenerator extends GeneratorBase {
     // arriving together on the new chord. The accent is additive (one-shot on top
     // of the looping pattern) so it doesn't require a Part rebuild.
     this.unsubConductor = getConductor().onChordChange(() => {
+      // Keep the kick tuned to the song key (cheap — no-ops when unchanged).
+      this.sampledKit.setKeyRoot(getConductor().getKeyPitchClass())
       const transport = Tone.getTransport()
       if (transport.state !== 'started') return
       // Chord fires 1 bar early (barNumber % 4 === 3); landing is next bar.
@@ -216,9 +219,29 @@ export class DrumGenerator extends GeneratorBase {
   // Tunable micro-timing and groove settings
   private lazySnareMinMs: number = 5
   private lazySnareMaxMs: number = 15
-  private hatCyclicPattern: number[] = [1.0, 0.4, 0.75, 0.5]
   private hatShuffleMinPct: number = 1.5
   private hatShuffleMaxPct: number = 3.0
+
+  // ── Groove template (the pocket) ──────────────────────────────────
+  // Per-16th-slot micro-timing offsets that are STABLE across bars and
+  // rebuilds — like an MPC groove template. The previous per-event
+  // Math.random() jitter re-rolled every hit on every rebuild: uncorrelated
+  // noise reads as a sloppy drummer, while the SAME slot always landing the
+  // same few ms late reads as a human pocket.
+  private grooveHatShiftPct: number[] = []   // shuffle push per 16th slot (off-16ths only)
+  private grooveSnareLagMs:  number[] = []   // lazy-snare lag per beat (0..3)
+
+  private buildGrooveTemplate(): void {
+    const rng = mulberry32(hashString(`groove:${this.currentPhysicsMode}`))
+    this.grooveHatShiftPct = Array.from({ length: 16 }, (_, slot) =>
+      slot % 2 === 1
+        ? this.hatShuffleMinPct + rng() * (this.hatShuffleMaxPct - this.hatShuffleMinPct)
+        : 0,
+    )
+    this.grooveSnareLagMs = Array.from({ length: 4 }, () =>
+      this.lazySnareMinMs + rng() * (this.lazySnareMaxMs - this.lazySnareMinMs),
+    )
+  }
 
   private enabled: boolean = true
 
@@ -236,17 +259,13 @@ export class DrumGenerator extends GeneratorBase {
   setLazySnareRange(minMs: number, maxMs: number): void {
     this.lazySnareMinMs = Math.max(0, minMs)
     this.lazySnareMaxMs = Math.max(minMs, maxMs)
-  }
-
-  setHatCyclicPattern(pattern: number[]): void {
-    if (pattern.length > 0) {
-      this.hatCyclicPattern = [...pattern]
-    }
+    this.buildGrooveTemplate()
   }
 
   setHatShuffleRange(minPct: number, maxPct: number): void {
     this.hatShuffleMinPct = Math.max(0, minPct)
     this.hatShuffleMaxPct = Math.max(minPct, maxPct)
+    this.buildGrooveTemplate()
   }
 
   setSectionDensity(density: number): void {
@@ -352,7 +371,12 @@ export class DrumGenerator extends GeneratorBase {
       case OState.Dormant:   return 0
       case OState.Awakening: return 0.25 * organism.awakeningProgress
       case OState.Breathing: return 0.56 * organism.breathingWarmth
-      case OState.Flow:      return 0.78
+      // 0.88 (was 0.78): the drums NEVER reached full level even in Flow, and
+      // after the serial compressor stack there was no makeup gain anywhere —
+      // the beat sat quiet against any reference, which reads as amateur before
+      // the notes are even judged. Master headroom (-9 dB) + the -0.3 dBFS
+      // WaveShaper ceiling absorb the increase safely.
+      case OState.Flow:      return 0.88
     }
   }
 
@@ -453,6 +477,7 @@ export class DrumGenerator extends GeneratorBase {
     const idx    = DrumGenerator.MODE_KIT_MAP[this.currentPhysicsMode] ?? 0
     const preset = DrumGenerator.KIT_PRESETS[idx]
     this.sampledKit.setMode(this.currentPhysicsMode)
+    this.buildGrooveTemplate()  // pocket is seeded per mode — stable until mode changes
     this.currentKickNote          = preset.kickNote
     this.kickSub.pitchDecay       = preset.kickPitchDecay
     this.kickSub.volume.rampTo(preset.kickVol, 0.3)
@@ -488,38 +513,33 @@ export class DrumGenerator extends GeneratorBase {
     this.currentHits = [...quantizedHits]   // snapshot for lockPattern()
     this.emitDrumEvents(quantizedHits)
 
+    // Groove template — stable per-slot offsets, NOT per-event randomness.
+    // NOTE: velocities pass through untouched. The pattern sources (freeplay
+    // improviser / authored library) already shape hat velocities; the old
+    // hatCyclicPattern multiply here was a SECOND attenuation that crushed
+    // 16th-infill hats to near-zero (0.22 pattern vel × 0.4 cycle = inaudible).
+    if (this.grooveHatShiftPct.length === 0) this.buildGrooveTemplate()
+
     const events = quantizedHits.map(h => {
       const parts = h.time.split(':')
       const beat = parseInt(parts[1] ?? '0', 10)
       const sub = parseFloat(parts[2] ?? '0')
-      
-      let microShift = 0
-      let velocity = h.velocity
 
-      // 1. Lazy Snare: On beats 2 and 4 (beat index 1 and 3), delay snare
+      let microShift = 0
+
+      // 1. Lazy Snare: backbeats (2 and 4) land late by the template's lag
       if (h.instrument === DrumInstrument.Snare && (beat === 1 || beat === 3) && sub === 0) {
-        const minSec = this.lazySnareMinMs / 1000
-        const maxSec = this.lazySnareMaxMs / 1000
-        microShift = minSec + Math.random() * (maxSec - minSec)
+        microShift = (this.grooveSnareLagMs[beat] ?? 0) / 1000
       }
 
-      // 2. Closed Hi-Hat adjustments
+      // 2. Hat shuffle: off-beat 16ths pushed late by the template's per-slot
+      //    percentage of a 16th — the same slot always lands the same amount late.
       if (h.instrument === DrumInstrument.Hat) {
         const sixteenthPos = Math.floor(beat * 4 + sub) % 16
-        
-        // Cyclic velocity pattern
-        const patternIndex = sixteenthPos % this.hatCyclicPattern.length
-        const patternVel = this.hatCyclicPattern[patternIndex] ?? 1.0
-        velocity = h.velocity * patternVel
-
-        // Hat Shuffle: Shift off-beat 16th notes late by shuffle bounds percentage of a 16th duration
-        const isOffBeat = sixteenthPos % 2 !== 0
-        if (isOffBeat) {
+        const shiftPct = (this.grooveHatShiftPct[sixteenthPos] ?? 0) / 100
+        if (shiftPct > 0) {
           const bpm = Tone.getTransport().bpm.value || 120
           const sixteenthDurationSec = 60 / (bpm * 4)
-          const minPct = this.hatShuffleMinPct / 100
-          const maxPct = this.hatShuffleMaxPct / 100
-          const shiftPct = minPct + Math.random() * (maxPct - minPct)
           microShift = shiftPct * sixteenthDurationSec
         }
       }
@@ -527,7 +547,7 @@ export class DrumGenerator extends GeneratorBase {
       return {
         time:       h.time,
         instrument: h.instrument,
-        velocity,
+        velocity:   h.velocity,
         microShift,
       }
     })
@@ -561,7 +581,9 @@ export class DrumGenerator extends GeneratorBase {
 
     this.part = new Tone.Part((time, event) => {
       const vel = this.applyDynamics(event.instrument, event.velocity)
-      this.triggerDrum(event.instrument, time + (event.microShift ?? 0), vel)
+      // Pattern velocity picks the voice (open vs closed hat); dynamics-adjusted
+      // velocity sets loudness — so a kick-duck can't flip an open hat closed.
+      this.triggerDrum(event.instrument, time + (event.microShift ?? 0), vel, event.velocity)
     }, events)
 
     this.part.loop    = true
@@ -703,12 +725,12 @@ export class DrumGenerator extends GeneratorBase {
     }
   }
 
-  private triggerDrum(instrument: DrumInstrument, time: number, velocity: number): void {
+  private triggerDrum(instrument: DrumInstrument, time: number, velocity: number, voiceVelocity = velocity): void {
     const t = Math.max(0, time)
 
-    const sampledVoice = instrument === DrumInstrument.Hat && velocity > 0.55 ? 'sampleHatOpen' : `sample${instrument}`
+    const sampledVoice = instrument === DrumInstrument.Hat && voiceVelocity > 0.55 ? 'sampleHatOpen' : `sample${instrument}`
     const sampledTime = this.clampTime(sampledVoice, t)
-    if (this.sampledKit.trigger(instrument, sampledTime, velocity)) {
+    if (this.sampledKit.trigger(instrument, sampledTime, velocity, voiceVelocity)) {
       if (instrument === DrumInstrument.Kick) {
         this.lastKickTime = sampledTime
         if (this.onKickTrigger) this.onKickTrigger(sampledTime)

--- a/client/src/organism/generators/SampledDrumKit.ts
+++ b/client/src/organism/generators/SampledDrumKit.ts
@@ -10,6 +10,7 @@ import {
   type SampleProfile,
   type GenreTarget,
 } from '../instruments/sampleProfileCache'
+import { detectFundamentalHz, tuneShiftSemitones } from '../instruments/pitchDetect'
 
 type SampleVoice = 'kick' | 'snare' | 'hatClosed' | 'hatOpen' | 'perc'
 
@@ -17,6 +18,20 @@ type SampleKitDefinition = Record<SampleVoice, string[]>
 type SampleVoiceSlot = {
   gain: Tone.Gain
   player: Tone.Player
+  url: string
+}
+
+/**
+ * Sampler-style velocity law with an audibility floor. The previous linear
+ * velocity→gain mapping put a 0.2-velocity ghost hat at −14 dB before the
+ * −14 dB voice trim even applied — the entire "feel" layer the improvisers
+ * write (ghost snares, 16th infill, velocity arcs) was effectively inaudible.
+ * The floor keeps quiet hits present; the power curve preserves accent contrast.
+ */
+export function velocityToGain(velocity: number): number {
+  const v = Math.max(0, Math.min(1, velocity))
+  if (v <= 0) return 0
+  return 0.12 + 0.88 * Math.pow(v, 1.35)
 }
 
 const PREFERRED_KIT_POOLS: Record<string, Partial<Record<SampleVoice, RegExp[]>>> = {
@@ -166,12 +181,16 @@ const VOICE_TRIM_DB: Record<SampleVoice, number> = {
   perc: -10,
 }
 
+// Playback windows — generous, not surgical. The old values (kick 0.65s,
+// hatOpen 0.5s) hard-truncated the one-shots' natural tails, which is exactly
+// the part that makes a produced kit sound expensive. Closed hat stays tight
+// by design (that IS the sample's character).
 const VOICE_DURATION: Record<SampleVoice, Tone.Unit.Time> = {
-  kick: 0.65,
-  snare: 0.45,
+  kick: 1.1,
+  snare: 0.7,
   hatClosed: 0.08,
-  hatOpen: 0.5,
-  perc: 0.22,
+  hatOpen: 0.85,
+  perc: 0.3,
 }
 
 const VOICE_POOL_SIZE: Record<SampleVoice, number> = {
@@ -265,6 +284,13 @@ export class SampledDrumKit {
   private profiles: Map<string, SampleProfile> = new Map()
   private genreTarget: GenreTarget = getGenreTarget('hip-hop')
 
+  // Key tuning — kicks are retuned onto the song's key root (≤ ±3 st) via
+  // playbackRate. Rates are detected off-thread (setTimeout) and cached per
+  // URL; until a rate is cached the kick plays untuned (rate 1) — never a
+  // blocking pitch analysis inside the trigger path.
+  private keyRootPc: number | null = null
+  private kickTuneRates = new Map<string, { pc: number; rate: number }>()
+
   constructor(output: Tone.Gain) {
     this.output = output
     // Seed the merged Cymatics kit (primary + fallback URLs) as the initial
@@ -342,7 +368,7 @@ export class SampledDrumKit {
         })
         player.volume.value = VOICE_TRIM_DB[voice]
         player.connect(gain)
-        voiceSlots.push({ gain, player })
+        voiceSlots.push({ gain, player, url: filename })
       }
 
       this.slots.set(voice, voiceSlots)
@@ -350,13 +376,26 @@ export class SampledDrumKit {
     }
   }
 
-  trigger(instrument: DrumInstrument, time: number, velocity: number): boolean {
-    const voice = this.resolveVoice(instrument, velocity)
+  /**
+   * @param velocity   post-dynamics velocity (kick-duck, multipliers) — sets loudness
+   * @param voiceVelocity pre-dynamics pattern velocity — selects the voice. Without
+   *   this split, an open-hat accent ducked by a nearby kick would mutate into a
+   *   CLOSED hat (timbre flapping), and freeplay could never reach the open hat.
+   */
+  trigger(instrument: DrumInstrument, time: number, velocity: number, voiceVelocity = velocity): boolean {
+    const voice = this.resolveVoice(instrument, voiceVelocity)
     const voiceSlots = this.slots.get(voice)
     if (!voiceSlots || voiceSlots.length === 0) return false
 
     const startCursor = this.slotCursor.get(voice) ?? 0
-    const shapedVelocity = Math.max(0, Math.min(1, velocity))
+    const shapedVelocity = velocityToGain(velocity)
+
+    // Backbeat snares layer the clap ON TOP of the snare (the producer move)
+    // instead of the round-robin cursor randomly alternating snare/clap hits.
+    // Clap slots are excluded from the primary scan when a non-clap snare exists.
+    const isClapSlot = (slot: SampleVoiceSlot) => /clap/i.test(slot.url)
+    const snareHasBoth = voice === 'snare'
+      && voiceSlots.some(isClapSlot) && voiceSlots.some(s => !isClapSlot(s))
 
     // Scan forward from cursor for the first usable slot.
     // Skips permanently-errored slots (404/network) so fallback URLs are used
@@ -369,6 +408,8 @@ export class SampledDrumKit {
       if (this.slotErrored.has(slotKey)) continue
 
       const slot = voiceSlots[slotIndex]
+      if (snareHasBoth && isClapSlot(slot)) continue  // claps are layer-only now
+
       // Advance cursor past this slot for the next trigger call
       this.slotCursor.set(voice, (slotIndex + 1) % voiceSlots.length)
 
@@ -378,9 +419,13 @@ export class SampledDrumKit {
       if (!slot.player.loaded) return true
 
       try {
+        if (voice === 'kick') this.applyKickTuning(slot)
         slot.gain.gain.cancelScheduledValues(time)
         slot.gain.gain.setValueAtTime(shapedVelocity, time)
         slot.player.start(time, 0, VOICE_DURATION[voice])
+        if (snareHasBoth && voiceVelocity >= 0.75) {
+          this.layerClap(voiceSlots, time, shapedVelocity)
+        }
         return true
       } catch (error) {
         // Scheduling error — mark as permanently failed and try the next slot
@@ -403,6 +448,55 @@ export class SampledDrumKit {
       console.warn('[Organism] all Cymatics drum slots exhausted for voice; going silent (no synth)', { voice })
     }
     return false
+  }
+
+  /** Set the song's key root (pitch class 0-11, null = no tuning). Kicks are
+   *  retuned onto it so the drum's sub sits in key with the 808 and chords. */
+  setKeyRoot(pc: number | null): void {
+    if (pc === this.keyRootPc) return
+    this.keyRootPc = pc
+    this.scheduleKickTuning()
+  }
+
+  /** Pre-compute tuning rates off the trigger path. Idempotent per (url, pc). */
+  private scheduleKickTuning(): void {
+    if (this.keyRootPc === null || typeof window === 'undefined') return
+    const pc = this.keyRootPc
+    window.setTimeout(() => {
+      if (this.keyRootPc !== pc) return
+      for (const slot of this.slots.get('kick') ?? []) {
+        if (this.kickTuneRates.get(slot.url)?.pc === pc) continue
+        const audio = slot.player.buffer?.loaded ? slot.player.buffer.get() : undefined
+        if (!audio) continue
+        const f0 = detectFundamentalHz(audio.getChannelData(0), audio.sampleRate)
+        const rate = f0 ? Math.pow(2, tuneShiftSemitones(f0, pc) / 12) : 1
+        this.kickTuneRates.set(slot.url, { pc, rate })
+      }
+    }, 0)
+  }
+
+  private applyKickTuning(slot: SampleVoiceSlot): void {
+    const cached = this.kickTuneRates.get(slot.url)
+    const rate = cached && cached.pc === this.keyRootPc ? cached.rate : 1
+    if (slot.player.playbackRate !== rate) slot.player.playbackRate = rate
+    // Not yet analyzed for this key — kick this URL's analysis off-thread.
+    if (!cached && this.keyRootPc !== null) this.scheduleKickTuning()
+  }
+
+  /** Stack the first loaded clap under a backbeat snare at reduced level. */
+  private layerClap(voiceSlots: SampleVoiceSlot[], time: number, snareGain: number): void {
+    for (let i = 0; i < voiceSlots.length; i++) {
+      const slot = voiceSlots[i]
+      if (!/clap/i.test(slot.url)) continue
+      if (this.slotErrored.has(`snare:${i}`)) continue
+      if (!slot.player.loaded) continue
+      try {
+        slot.gain.gain.cancelScheduledValues(time)
+        slot.gain.gain.setValueAtTime(snareGain * 0.55, time)
+        slot.player.start(time, 0, VOICE_DURATION.snare)
+      } catch { /* layer is decorative — never fail the primary hit over it */ }
+      return
+    }
   }
 
   dispose(): void {

--- a/client/src/organism/generators/freeplay/DrumImproviser.ts
+++ b/client/src/organism/generators/freeplay/DrumImproviser.ts
@@ -8,25 +8,40 @@ import type { FreeplayContext } from './types'
 import { getSectionMotif } from './motif'
 import { swungTime, jitterVel } from './utils'
 
-/** Immutable per-genre backbone (16th slots 0..15). Slot 4 = beat 2, 12 = beat 4. */
-export const SKELETONS: Record<string, { kicks: number[]; snares: number[] }> = {
-  'boom-bap':    { kicks: [0, 6, 10],        snares: [4, 12] },
-  'trap':        { kicks: [0, 10],           snares: [8] },        // half-time clap on 3
-  'drill':       { kicks: [0, 9],            snares: [8] },
-  'lo-fi':       { kicks: [0, 8],            snares: [4, 12] },
-  'west-coast':  { kicks: [0, 7, 10],        snares: [4, 12] },
-  'dirty-south': { kicks: [0, 6],            snares: [4, 12] },
-  'phonk':       { kicks: [0, 7, 11],        snares: [4, 12] },
-  'jersey-club': { kicks: [0, 6, 10, 13],    snares: [4, 12] },
-  'bounce':      { kicks: [0, 7, 10],        snares: [4, 12] },
-  'reggaeton':   { kicks: [0, 4, 8, 12],     snares: [3, 7, 11, 14] }, // dembow
-  'afrobeat':    { kicks: [0, 7],            snares: [4, 12] },
-  'chill':       { kicks: [0, 8],            snares: [4, 12] },
+/** Immutable per-genre backbone (16th slots 0..15). Slot 4 = beat 2, 12 = beat 4.
+ *  `kicks` is the bar-A pattern; `kicksB` answers it on odd bars — hip-hop kick
+ *  programming lives on a 2-bar call/response cycle, and looping a single bar of
+ *  kicks ×4 was the strongest remaining "it feels looped" signal. Genres whose
+ *  kick pattern IS the genre (jersey club, reggaeton dembow) keep A === B. */
+export const SKELETONS: Record<string, { kicks: number[]; kicksB: number[]; snares: number[] }> = {
+  'boom-bap':    { kicks: [0, 6, 10],     kicksB: [0, 7, 10],     snares: [4, 12] },
+  'trap':        { kicks: [0, 10],        kicksB: [0, 6, 13],     snares: [8] },        // half-time clap on 3
+  'drill':       { kicks: [0, 9],         kicksB: [0, 9, 14],     snares: [8] },
+  'lo-fi':       { kicks: [0, 8],         kicksB: [0, 8, 11],     snares: [4, 12] },
+  'west-coast':  { kicks: [0, 7, 10],     kicksB: [0, 7, 11],     snares: [4, 12] },
+  'dirty-south': { kicks: [0, 6],         kicksB: [0, 6, 11],     snares: [4, 12] },
+  'phonk':       { kicks: [0, 7, 11],     kicksB: [0, 7, 14],     snares: [4, 12] },
+  'jersey-club': { kicks: [0, 6, 10, 13], kicksB: [0, 6, 10, 13], snares: [4, 12] },
+  'bounce':      { kicks: [0, 7, 10],     kicksB: [0, 3, 10],     snares: [4, 12] },
+  'reggaeton':   { kicks: [0, 4, 8, 12],  kicksB: [0, 4, 8, 12],  snares: [3, 7, 11, 14] }, // dembow
+  'afrobeat':    { kicks: [0, 7],         kicksB: [0, 7, 10],     snares: [4, 12] },
+  'chill':       { kicks: [0, 8],         kicksB: [0, 8],         snares: [4, 12] },
 }
 
 const K = DrumInstrument.Kick
 const S = DrumInstrument.Snare
 const H = DrumInstrument.Hat
+const P = DrumInstrument.Perc
+
+/** Open-hat accents live on the off-beat 8ths ("the and"). Velocity must clear
+ *  the kit's open/closed split (>0.55 in SampledDrumKit.resolveVoice). */
+const OPEN_HAT_CANDIDATES = [6, 14, 2, 10]
+const OPEN_HAT_VELOCITY = 0.68
+
+/** Fill flavours for the last beat of bar 4 — rotating so consecutive phrases
+ *  don't all end on the same ascending snare run (the stockest fill there is). */
+type FillType = 'snare-run' | 'kick-stutter' | 'cut' | 'perc-run'
+const FILL_TYPES: FillType[] = ['snare-run', 'kick-stutter', 'cut', 'perc-run']
 
 function push(hits: DrumHit[], inst: DrumInstrument, bar: number, slot: number, vel: number, swing: number, rng: () => number): void {
   hits.push({ instrument: inst, time: swungTime(bar, slot, swing), velocity: jitterVel(vel, rng) })
@@ -36,9 +51,10 @@ export function buildFreeplayDrumHits(ctx: FreeplayContext): DrumHit[] {
   const skeleton = SKELETONS[ctx.subGenre] ?? SKELETONS['boom-bap']
   const hits: DrumHit[] = []
 
-  // Slots forbidden for improvised additions: the backbone and its neighbours.
+  // Slots forbidden for improvised additions: the backbone (both bar variants)
+  // and its neighbours.
   const protectedSlots = new Set<number>()
-  for (const s of [...skeleton.kicks, ...skeleton.snares]) {
+  for (const s of [...skeleton.kicks, ...skeleton.kicksB, ...skeleton.snares]) {
     protectedSlots.add(s); protectedSlots.add(s - 1); protectedSlots.add(s + 1)
   }
 
@@ -56,11 +72,32 @@ export function buildFreeplayDrumHits(ctx: FreeplayContext): DrumHit[] {
     .filter(s => !protectedSlots.has(s) && s % 4 !== 0)
     .slice(0, 2)
 
+  // Hat 16th infill is MOTIF-driven, not a per-slot coin flip: a committed set
+  // of off-16th slots per section so the infill is a repeating idea the ear can
+  // lock onto, with a small rng sparkle on top.
+  const hatInfill = new Set(
+    getSectionMotif(`hats:${ctx.sectionName}:${ctx.subGenre}`, ctx.rng, ctx.density, [])
+      .slots.map(s => (s + 1) % 16)      // shift motif onto the off-16ths
+      .filter(s => s % 2 === 1),
+  )
+
+  // 0-2 open-hat accents per bar, drawn once per phrase so the placement is an
+  // idea, not noise. Kept off slots where the closed 8th grid would double them.
+  const openHatSlots = OPEN_HAT_CANDIDATES
+    .filter(() => ctx.rng() < 0.25 + ctx.density * 0.35)
+    .slice(0, 2)
+
+  // Pick this phrase's fill flavour up front so the hat loop can honour a
+  // "cut" fill (silence IS the fill) by leaving the last beat empty.
+  const fillType: FillType = FILL_TYPES[Math.floor(ctx.rng() * FILL_TYPES.length)]
+
   for (let bar = 0; bar < ctx.bars; bar++) {
     const isFillBar = bar === ctx.bars - 1
+    const cutFill = isFillBar && ctx.energy >= 0.3 && fillType === 'cut'
+    const barKicks = bar % 2 === 0 ? skeleton.kicks : skeleton.kicksB
 
-    // 1) Skeleton (immutable, loud)
-    for (const s of skeleton.kicks) push(hits, K, bar, s, 0.95, ctx.swing, ctx.rng)
+    // 1) Skeleton (immutable, loud) — bar A / bar B kick call-and-response
+    for (const s of barKicks) push(hits, K, bar, s, 0.95, ctx.swing, ctx.rng)
     for (const s of skeleton.snares) push(hits, S, bar, s, 0.9, ctx.swing, ctx.rng)
 
     // 2) Improvised extra kicks (quieter than the backbone)
@@ -68,20 +105,28 @@ export function buildFreeplayDrumHits(ctx: FreeplayContext): DrumHit[] {
       if (ctx.rng() < 0.8) push(hits, K, bar, s, 0.6, ctx.swing, ctx.rng)
     }
 
-    // 3) Hats: 8ths always; 16th infill probability scales with density;
-    //    occasional roll replaces the last 8th of odd bars at high energy.
+    // 3) Hats: 8ths always (open-hat accents on chosen "ands"); 16th infill
+    //    from the committed motif; occasional roll replaces the last 8th of
+    //    odd bars at high energy.
     for (let slot = 0; slot < 16; slot++) {
+      if (cutFill && slot >= 12) continue // fill = silence, let the beat breathe
       const isEighth = slot % 2 === 0
       const rollZone = slot >= 14 && bar % 2 === 1 && ctx.energy > 0.6
       if (rollZone) continue // handled below
       if (isEighth) {
-        const accent = slot % 4 === 0 ? 0.48 : 0.35
-        push(hits, H, bar, slot, accent, ctx.swing, ctx.rng)
-      } else if (ctx.rng() < ctx.density * 0.5) {
-        push(hits, H, bar, slot, 0.22, ctx.swing, ctx.rng)
+        if (openHatSlots.includes(slot)) {
+          push(hits, H, bar, slot, OPEN_HAT_VELOCITY, ctx.swing, ctx.rng)
+        } else {
+          const accent = slot % 4 === 0 ? 0.48 : 0.35
+          push(hits, H, bar, slot, accent, ctx.swing, ctx.rng)
+        }
+      } else if (hatInfill.has(slot) && ctx.rng() < 0.35 + ctx.density * 0.5) {
+        push(hits, H, bar, slot, 0.24, ctx.swing, ctx.rng)
+      } else if (ctx.rng() < ctx.density * 0.05) {
+        push(hits, H, bar, slot, 0.18, ctx.swing, ctx.rng) // rare sparkle outside the motif
       }
     }
-    if (bar % 2 === 1 && ctx.energy > 0.6 && ctx.rng() < 0.7) {
+    if (bar % 2 === 1 && ctx.energy > 0.6 && !cutFill && ctx.rng() < 0.7) {
       // 32nd hat roll across the last two 16ths (slots 14-15 as 4 hits)
       for (let i = 0; i < 4; i++) {
         hits.push({
@@ -99,10 +144,32 @@ export function buildFreeplayDrumHits(ctx: FreeplayContext): DrumHit[] {
       }
     }
 
-    // 5) Fill: last beat of bar 4, intensity from energy
+    // 5) Fill: last beat of bar 4, flavour rotates per phrase, intensity from energy
     if (isFillBar && ctx.energy >= 0.3) {
-      const fillSlots = ctx.energy > 0.7 ? [12, 13, 14, 15] : [13, 14, 15]
-      fillSlots.forEach((s, i) => push(hits, S, bar, s, 0.5 + i * 0.12, ctx.swing, ctx.rng))
+      const hot = ctx.energy > 0.7
+      switch (fillType) {
+        case 'snare-run': {
+          const fillSlots = hot ? [12, 13, 14, 15] : [13, 14, 15]
+          fillSlots.forEach((s, i) => push(hits, S, bar, s, 0.5 + i * 0.12, ctx.swing, ctx.rng))
+          break
+        }
+        case 'kick-stutter': {
+          push(hits, K, bar, 12, 0.75, ctx.swing, ctx.rng)
+          push(hits, K, bar, 14, 0.55, ctx.swing, ctx.rng)
+          push(hits, S, bar, 15, hot ? 0.7 : 0.55, ctx.swing, ctx.rng)
+          break
+        }
+        case 'cut': {
+          // Hats already muted for slots 12-15 above; one lone snare marks the gap.
+          push(hits, S, bar, 14, 0.6, ctx.swing, ctx.rng)
+          break
+        }
+        case 'perc-run': {
+          const fillSlots = hot ? [12, 13, 14, 15] : [13, 14, 15]
+          fillSlots.forEach((s, i) => push(hits, P, bar, s, 0.45 + i * 0.1, ctx.swing, ctx.rng))
+          break
+        }
+      }
     }
   }
 

--- a/client/src/organism/generators/freeplay/__tests__/DrumImproviser.test.ts
+++ b/client/src/organism/generators/freeplay/__tests__/DrumImproviser.test.ts
@@ -23,14 +23,30 @@ const slotOf = (t: string) => {
 describe('DrumImproviser', () => {
   beforeEach(() => clearMotifs())
 
-  it('the sub-genre skeleton is IMMUTABLE — every bar contains every anchor', () => {
+  it('the sub-genre skeleton is IMMUTABLE — bar A/B anchors present on their bars', () => {
     const hits = buildFreeplayDrumHits(ctx())
-    const { kicks, snares } = SKELETONS['boom-bap']
+    const { kicks, kicksB, snares } = SKELETONS['boom-bap']
     for (let bar = 0; bar < 4; bar++) {
       const kickSlots = hits.filter(h => h.instrument === 'kick' && slotOf(h.time).bar === bar).map(h => slotOf(h.time).slot)
       const snareSlots = hits.filter(h => h.instrument === 'snare' && slotOf(h.time).bar === bar && h.velocity > 0.4).map(h => slotOf(h.time).slot)
-      for (const k of kicks) expect(kickSlots).toContain(k)
+      const barKicks = bar % 2 === 0 ? kicks : kicksB
+      for (const k of barKicks) expect(kickSlots).toContain(k)
       for (const s of snares) expect(snareSlots).toContain(s)
+    }
+  })
+
+  it('kick programming is a 2-bar cycle — bar B answers bar A for most genres', () => {
+    // Genres whose kick IS the genre identity keep A === B; the rest must differ.
+    const identical = ['jersey-club', 'reggaeton', 'chill']
+    for (const [genre, sk] of Object.entries(SKELETONS)) {
+      if (identical.includes(genre)) {
+        expect(sk.kicksB, genre).toEqual(sk.kicks)
+      } else {
+        expect(sk.kicksB, genre).not.toEqual(sk.kicks)
+      }
+      // Both bars keep the downbeat anchor
+      expect(sk.kicks).toContain(0)
+      expect(sk.kicksB).toContain(0)
     }
   })
 
@@ -42,9 +58,12 @@ describe('DrumImproviser', () => {
     for (let seed = 0; seed < 15; seed++) {
       clearMotifs()
       const hits = buildFreeplayDrumHits(ctx({ rng: mulberry32(seed), density: 1.0 }))
-      const skeletonKicks = new Set(SKELETONS['boom-bap'].kicks)
+      const sk = SKELETONS['boom-bap']
+      const skeletonKicks = new Set([...sk.kicks, ...sk.kicksB])
       const extraKicks = hits.filter(h =>
-        h.instrument === 'kick' && !skeletonKicks.has(slotOf(h.time).slot))
+        h.instrument === 'kick' && !skeletonKicks.has(slotOf(h.time).slot)
+        // fill-bar kick stutters (slots 12/14 on bar 3) are a fill, not floor kicks
+        && !(slotOf(h.time).bar === 3 && slotOf(h.time).slot >= 12))
       for (const k of extraKicks) {
         expect(slotOf(k.time).slot % 4, `extra kick on quarter-note slot ${slotOf(k.time).slot} (seed ${seed})`).not.toBe(0)
       }
@@ -63,11 +82,47 @@ describe('DrumImproviser', () => {
     expect(hats(busy)).toBeGreaterThan(hats(sparse))
   })
 
-  it('bar 4 contains a fill (extra snares on the last beat) when energy is high', () => {
-    const hits = buildFreeplayDrumHits(ctx({ energy: 0.9 }))
-    const lastBeatSnares = hits.filter(h =>
-      h.instrument === 'snare' && slotOf(h.time).bar === 3 && slotOf(h.time).slot >= 12)
-    expect(lastBeatSnares.length).toBeGreaterThanOrEqual(3)
+  it('16th hat infill repeats as a motif — same off-16th slots recur across bars', () => {
+    const hits = buildFreeplayDrumHits(ctx({ density: 1.0 }))
+    const offSixteenthSlots = (bar: number) => new Set(
+      hits.filter(h => h.instrument === 'hat' && slotOf(h.time).bar === bar && slotOf(h.time).slot % 2 === 1)
+        .map(h => slotOf(h.time).slot))
+    // Union of infill slots across bars 0-2 should be small (a committed idea),
+    // not spread across all 8 off-16th positions like a coin flip would.
+    const union = new Set([...offSixteenthSlots(0), ...offSixteenthSlots(1), ...offSixteenthSlots(2)])
+    expect(union.size).toBeLessThanOrEqual(6)
+  })
+
+  it('open-hat accents fire above the kit open/closed velocity split (>0.55)', () => {
+    // Across seeds, at least some phrases must contain open-hat-capable velocities
+    // on the off-beat 8ths — before this, freeplay could never trigger an open hat.
+    let found = 0
+    for (let seed = 0; seed < 10; seed++) {
+      clearMotifs()
+      const hits = buildFreeplayDrumHits(ctx({ rng: mulberry32(seed), density: 0.8 }))
+      if (hits.some(h => h.instrument === 'hat' && h.velocity > 0.55 && slotOf(h.time).slot % 2 === 0)) found++
+    }
+    expect(found).toBeGreaterThan(3)
+  })
+
+  it('bar 4 contains a fill when energy is high, and fill flavours rotate across seeds', () => {
+    const seen = new Set<string>()
+    for (let seed = 0; seed < 24; seed++) {
+      clearMotifs()
+      const hits = buildFreeplayDrumHits(ctx({ rng: mulberry32(seed), energy: 0.9 }))
+      const lastBeat = hits.filter(h => slotOf(h.time).bar === 3 && slotOf(h.time).slot >= 12)
+      const snares = lastBeat.filter(h => h.instrument === 'snare' && !SKELETONS['boom-bap'].snares.includes(slotOf(h.time).slot))
+      const kicks = lastBeat.filter(h => h.instrument === 'kick' && slotOf(h.time).slot >= 12)
+      const percs = lastBeat.filter(h => h.instrument === 'perc')
+      const hats = lastBeat.filter(h => h.instrument === 'hat')
+      if (snares.length >= 3) seen.add('snare-run')
+      else if (kicks.length >= 2) seen.add('kick-stutter')
+      else if (percs.length >= 3) seen.add('perc-run')
+      else if (hats.length === 0 && snares.length >= 1) seen.add('cut')
+      // Every phrase must end with SOME fill statement
+      expect(snares.length + kicks.length + percs.length, `no fill at seed ${seed}`).toBeGreaterThanOrEqual(1)
+    }
+    expect(seen.size, `only saw fill types: ${[...seen].join(', ')}`).toBeGreaterThanOrEqual(3)
   })
 
   it('no fill when energy is low (intro stays clean)', () => {

--- a/client/src/organism/instruments/Real808BassSampler.ts
+++ b/client/src/organism/instruments/Real808BassSampler.ts
@@ -1,5 +1,7 @@
 import * as Tone from 'tone'
 import type { OrganismKitSample } from './OrganismKitCache'
+import { detectFundamentalHz, hzToMidi } from './pitchDetect'
+import { midiToNote } from '../generators/freeplay/utils'
 export { findBass808Sample } from './OrganismKitCache'
 
 export type Real808BassSample = OrganismKitSample
@@ -42,26 +44,48 @@ export class Real808BassSampler {
     if (this.loadPromise) return this.loadPromise
     this.state = 'loading'
 
-    const rootNote = sample.rootNote || this.rootNote
-
+    // The metadata rootNote is a guess ('C1' fallback) — and a wrong root makes
+    // every melodic 808 line consistently sharp/flat against the chords. Load
+    // the buffer first, MEASURE the sample's true fundamental, and key the
+    // sampler on the detected root instead. Metadata is kept as the fallback
+    // when the detector finds no confident pitch.
     this.loadPromise = new Promise((resolve) => {
-      this.sampler = new Tone.Sampler({
-        urls: { [rootNote]: sample.url },
-        attack: 0.001,
-        release: 2.5,
-        volume: this.volume,
-        onload: () => {
+      const buffer = new Tone.ToneAudioBuffer(
+        sample.url,
+        () => {
+          let rootNote = sample.rootNote || this.rootNote
+          try {
+            const audio = buffer.get()
+            if (audio) {
+              const f0 = detectFundamentalHz(audio.getChannelData(0), audio.sampleRate)
+              if (f0) {
+                const detected = midiToNote(Math.round(hzToMidi(f0)))
+                if (detected !== rootNote) {
+                  console.info('[Real808BassSampler] tuned 808 root by ear', {
+                    metadataRoot: sample.rootNote ?? null, detectedRoot: detected, f0: Math.round(f0 * 10) / 10,
+                  })
+                }
+                rootNote = detected
+              }
+            }
+          } catch { /* detection is an enhancement — metadata root still works */ }
+
+          this.sampler = new Tone.Sampler({
+            urls: { [rootNote]: buffer },
+            attack: 0.001,
+            release: 2.5,
+            volume: this.volume,
+          })
+          this.sampler.connect(this.output)
           this.state = 'loaded'
           resolve()
         },
-        onerror: (err) => {
+        (err) => {
           console.warn('[Real808BassSampler] failed to load 808 sample', { sampleUrl: sample.url, err })
           this.state = 'error'
           resolve()
         },
-      })
-      this.sampler.connect(this.output)
-
+      )
     })
 
     return this.loadPromise

--- a/client/src/organism/instruments/__tests__/pitchDetect.test.ts
+++ b/client/src/organism/instruments/__tests__/pitchDetect.test.ts
@@ -1,0 +1,84 @@
+// client/src/organism/instruments/__tests__/pitchDetect.test.ts
+import { describe, it, expect } from 'vitest'
+import { detectFundamentalHz, hzToMidi, tuneShiftSemitones } from '../pitchDetect'
+
+const SR = 44100
+
+/** Synthesized decaying sine — a stand-in for an 808/kick body. */
+function sine(hz: number, seconds: number, decay = 2): Float32Array {
+  const out = new Float32Array(Math.floor(SR * seconds))
+  for (let i = 0; i < out.length; i++) {
+    const t = i / SR
+    out[i] = Math.sin(2 * Math.PI * hz * t) * Math.exp(-decay * t)
+  }
+  return out
+}
+
+/** Kick-style downward pitch sweep settling on `settleHz`. */
+function sweepKick(settleHz: number, seconds: number): Float32Array {
+  const out = new Float32Array(Math.floor(SR * seconds))
+  let phase = 0
+  for (let i = 0; i < out.length; i++) {
+    const t = i / SR
+    const hz = settleHz * (1 + 3 * Math.exp(-t / 0.02)) // 4× start, settles fast
+    phase += (2 * Math.PI * hz) / SR
+    out[i] = Math.sin(phase) * Math.exp(-3 * t)
+  }
+  return out
+}
+
+describe('detectFundamentalHz', () => {
+  it('finds a clean sub sine within 1 Hz', () => {
+    for (const hz of [40, 55, 80, 110]) {
+      const f0 = detectFundamentalHz(sine(hz, 0.8), SR)
+      expect(f0, `${hz} Hz`).not.toBeNull()
+      expect(Math.abs(f0! - hz), `${hz} Hz → ${f0}`).toBeLessThan(1)
+    }
+  })
+
+  it('measures the settled tail of a pitch-sweeping kick, not the transient', () => {
+    const f0 = detectFundamentalHz(sweepKick(50, 0.8), SR)
+    expect(f0).not.toBeNull()
+    expect(Math.abs(f0! - 50)).toBeLessThan(3)
+  })
+
+  it('returns null for noise (snares/claps must not get a bogus pitch)', () => {
+    const noise = new Float32Array(SR)
+    let seed = 1
+    for (let i = 0; i < noise.length; i++) {
+      seed = (seed * 16807) % 2147483647
+      noise[i] = seed / 2147483647 - 0.5
+    }
+    expect(detectFundamentalHz(noise, SR)).toBeNull()
+  })
+
+  it('returns null for too-short input', () => {
+    expect(detectFundamentalHz(sine(55, 0.05), SR)).toBeNull()
+  })
+})
+
+describe('hzToMidi', () => {
+  it('maps A4/A1 correctly', () => {
+    expect(hzToMidi(440)).toBeCloseTo(69, 5)
+    expect(hzToMidi(55)).toBeCloseTo(33, 5)
+  })
+})
+
+describe('tuneShiftSemitones', () => {
+  it('is 0 when already on the key root', () => {
+    // 55 Hz = A1 (pc 9); key of A
+    expect(Math.abs(tuneShiftSemitones(55, 9))).toBeLessThan(0.01)
+  })
+
+  it('retunes to the nearest octave of the root when close', () => {
+    // 58 Hz ≈ A#1 minus a bit; key of A → small downward shift
+    const shift = tuneShiftSemitones(58, 9)
+    expect(shift).toBeLessThan(0)
+    expect(shift).toBeGreaterThan(-1.5)
+  })
+
+  it('leaves the sample alone when the shift would exceed the clamp', () => {
+    // 50 Hz sits ~4.6 st below C; pulling that far changes the drum's character
+    expect(tuneShiftSemitones(50, 0)).toBe(0)
+  })
+})

--- a/client/src/organism/instruments/pitchDetect.ts
+++ b/client/src/organism/instruments/pitchDetect.ts
@@ -1,0 +1,134 @@
+// Pure fundamental-pitch detection for drum/808 samples. NO tone imports —
+// operates on raw Float32Array channel data so it is unit-testable and can run
+// on any decoded AudioBuffer.
+//
+// Used to tune kicks/808s to the song key: nothing in the sample profiles
+// stores pitch, and the 808 sampler previously trusted `rootNote || 'C1'`,
+// which plays every melodic 808 line consistently off against the chords when
+// the metadata is wrong.
+
+/**
+ * Detect the fundamental frequency of a low-pitched one-shot (kick / 808).
+ *
+ * Autocorrelation over the sample's TAIL — kicks pitch-sweep downward, so the
+ * first ~40ms transient is skipped and the settled sub region is measured.
+ * Search is limited to the sub/bass range so hats or noise can never produce
+ * a bogus "pitch".
+ *
+ * @returns frequency in Hz, or null when no confident pitch is found
+ */
+export function detectFundamentalHz(
+  data: Float32Array,
+  sampleRate: number,
+  minHz = 25,
+  maxHz = 200,
+): number | null {
+  if (sampleRate <= 0 || data.length === 0) return null
+
+  // Decimate ×4 — plenty of bandwidth for a ≤200 Hz search, 16× cheaper.
+  const dec = 4
+  const sr = sampleRate / dec
+  const decimated = new Float32Array(Math.floor(data.length / dec))
+  for (let i = 0; i < decimated.length; i++) {
+    const j = i * dec
+    decimated[i] = (data[j] + data[j + 1] + data[j + 2] + data[j + 3]) / 4
+  }
+
+  // Analysis window: skip the 40ms transient, use up to 400ms of the body.
+  const start = Math.floor(0.04 * sr)
+  const maxLag = Math.floor(sr / minHz)
+  const winLen = Math.min(decimated.length - start, Math.floor(0.4 * sr))
+  // Need at least two periods of the lowest searchable pitch.
+  if (winLen < maxLag * 2) return null
+
+  // Remove DC so a sub-heavy asymmetric waveform doesn't bias the correlation.
+  const seg = decimated.subarray(start, start + winLen)
+  let mean = 0
+  for (let i = 0; i < seg.length; i++) mean += seg[i]
+  mean /= seg.length
+
+  const minLag = Math.max(1, Math.ceil(sr / maxHz))
+  const n = seg.length - maxLag
+
+  const rs = new Float32Array(maxLag + 1)
+  let bestR = 0
+  for (let lag = minLag; lag <= maxLag; lag++) {
+    let dot = 0
+    let e0 = 0
+    let e1 = 0
+    for (let i = 0; i < n; i++) {
+      const a = seg[i] - mean
+      const b = seg[i + lag] - mean
+      dot += a * b
+      e0 += a * a
+      e1 += b * b
+    }
+    const denom = Math.sqrt(e0 * e1)
+    const r = denom > 0 ? dot / denom : 0
+    rs[lag] = r
+    if (r > bestR) bestR = r
+  }
+
+  // Confidence gate — noise/inharmonic material (snares, claps) lands well
+  // below this and correctly returns "no pitch".
+  if (bestR < 0.5) return null
+
+  // Octave-error guard: a periodic signal correlates equally well at 2×/3× the
+  // true period, and the global max can land there. Take the SMALLEST lag whose
+  // local peak is nearly as strong as the global best — that is the fundamental.
+  let bestLag = -1
+  for (let lag = minLag + 1; lag < maxLag; lag++) {
+    if (rs[lag] >= rs[lag - 1] && rs[lag] >= rs[lag + 1] && rs[lag] >= bestR * 0.95) {
+      bestLag = lag
+      break
+    }
+  }
+  if (bestLag < 0) return null
+
+  // Parabolic interpolation around the peak for sub-lag precision.
+  let lag = bestLag
+  if (bestLag > minLag && bestLag < maxLag) {
+    const rAt = (l: number) => {
+      let dot = 0
+      for (let i = 0; i < n; i++) dot += (seg[i] - mean) * (seg[i + l] - mean)
+      return dot
+    }
+    const y0 = rAt(bestLag - 1)
+    const y1 = rAt(bestLag)
+    const y2 = rAt(bestLag + 1)
+    const denom = y0 - 2 * y1 + y2
+    if (denom !== 0) {
+      const shift = 0.5 * (y0 - y2) / denom
+      if (Math.abs(shift) < 1) lag = bestLag + shift
+    }
+  }
+
+  return sr / lag
+}
+
+/** Frequency → fractional MIDI note number (69 = A4 = 440 Hz). */
+export function hzToMidi(hz: number): number {
+  return 69 + 12 * Math.log2(hz / 440)
+}
+
+/**
+ * Semitones to retune a detected pitch onto a key root, or 0 when the sample
+ * should be left alone.
+ *
+ * The shift targets the nearest octave of the key root's pitch class and is
+ * only applied when small (≤ maxShift semitones): a kick pulled 4-5 semitones
+ * becomes a different drum, which is worse than being off-key.
+ */
+export function tuneShiftSemitones(
+  detectedHz: number,
+  keyRootPitchClass: number,
+  maxShift = 3,
+): number {
+  if (!(detectedHz > 0)) return 0
+  const midi = hzToMidi(detectedHz)
+  const pc = ((midi % 12) + 12) % 12
+  // Wrapped pitch-class distance in (-6, 6]
+  let shift = (((keyRootPitchClass - pc) % 12) + 12) % 12
+  if (shift > 6) shift -= 12
+  return Math.abs(shift) <= maxShift ? shift : 0
+}

--- a/client/src/organism/mix/MixEngine.ts
+++ b/client/src/organism/mix/MixEngine.ts
@@ -27,9 +27,10 @@ export class MixEngine {
   readonly bandMaster:      Tone.Gain
   readonly drumBus:         Tone.Gain
   readonly drumCompressor:  Tone.Compressor
+  readonly drumParallelWet: Tone.Gain
   readonly melodyBus:       Tone.Gain
-  readonly melodySplit:     Tone.Split
-  readonly melodyMerge:     Tone.Merge
+  readonly textureSplit:    Tone.Split
+  readonly textureMerge:    Tone.Merge
   readonly haasDelay:       Tone.Delay
 
   private meterCallbacks: Set<MeterCallback> = new Set()
@@ -53,42 +54,54 @@ export class MixEngine {
     // 1. Initialize band master gain node (for silencing the generative engine)
     this.bandMaster = new Tone.Gain(1)
 
-    // 2. Drum Bus (Kick, Snare, Percussion, Bass/808) with parallel compression
+    // 2. Drum Bus (Kick, Snare, Percussion, Bass/808) with TRUE parallel (NY)
+    // compression. The previous wiring inserted this compressor SERIALLY —
+    // there was no dry path, so drums+bass were squashed 4:1 on top of the
+    // per-channel comps and the master glue comp (four compressors in series =
+    // no kick thwack, pumping 808). Now the dry bus carries the transients and
+    // a hard-crushed copy is blended UNDER it for density: punch AND weight.
     this.drumBus = new Tone.Gain(1)
     this.drumCompressor = new Tone.Compressor({
-      threshold: -12,
-      ratio: 4,
-      attack: 0.04,  // 40ms attack lets transients pop
-      release: 0.1,  // 100ms release induces pumping
+      threshold: -24,
+      ratio: 6,
+      attack: 0.003,  // fast — the wet path is meant to be crushed
+      release: 0.15,
     })
+    this.drumParallelWet = new Tone.Gain(0.45)
 
     this.drumChannel.output.connect(this.drumBus)
     this.bassChannel.output.connect(this.drumBus)
-    this.drumBus.connect(this.drumCompressor)
-    this.drumCompressor.connect(this.bandMaster)
+    this.drumBus.connect(this.bandMaster)              // dry — transients intact
+    this.drumBus.connect(this.drumCompressor)          // wet — crushed for density
+    this.drumCompressor.connect(this.drumParallelWet)
+    this.drumParallelWet.connect(this.bandMaster)
 
-    // 3. Melody Bus (Keys, Chords, Textures) with Haas stereo widening
+    // 3. Melody Bus (Keys, Chords) — DIRECT to the band master. The blanket
+    // 18ms Haas delay that used to sit on this whole bus comb-filtered every
+    // melodic element in mono and smeared the top end; placement now comes
+    // from the per-channel panners (melody +0.15, chord -0.10).
     this.melodyBus = new Tone.Gain(1)
-    this.melodySplit = new Tone.Split(2)
-    this.melodyMerge = new Tone.Merge()
+    this.melodyChannel.output.connect(this.melodyBus)
+    this.chordChannel.output.connect(this.melodyBus)
+    this.melodyBus.connect(this.bandMaster)
+
+    // 4. Texture keeps the Haas widening — pads/atmosphere are exactly where
+    // wide-and-diffuse is wanted, and the channel is quiet (-14 dB) so the
+    // mono comb-filter cost is negligible there.
+    this.textureSplit = new Tone.Split(2)
+    this.textureMerge = new Tone.Merge()
     this.haasDelay = new Tone.Delay({
       delayTime: 0.018, // 18ms delay on the Right channel
       maxDelay: 0.1,
     })
 
-    this.melodyChannel.output.connect(this.melodyBus)
-    this.chordChannel.output.connect(this.melodyBus)
-    this.textureChannel.output.connect(this.melodyBus)
+    this.textureChannel.output.connect(this.textureSplit)
+    this.textureSplit.connect(this.textureMerge, 0, 0) // Left -> Left
+    this.textureSplit.connect(this.haasDelay, 1, 0)    // Right -> Delay
+    this.haasDelay.connect(this.textureMerge, 0, 1)    // Delay -> Right
+    this.textureMerge.connect(this.bandMaster)
 
-    // Haas Effect routing: Left directly to Merge; Right through Delay to Merge
-    this.melodyBus.connect(this.melodySplit)
-    this.melodySplit.connect(this.melodyMerge, 0, 0) // Left -> Left
-    this.melodySplit.connect(this.haasDelay, 1, 0)  // Right -> Delay
-    this.haasDelay.connect(this.melodyMerge, 0, 1)  // Delay -> Right
-
-    this.melodyMerge.connect(this.bandMaster)
-
-    // 4. Connect the summed bandMaster output to the master bus input
+    // 5. Connect the summed bandMaster output to the master bus input
     this.bandMaster.connect(this.master.input)
   }
 
@@ -224,10 +237,11 @@ export class MixEngine {
     
     try { this.drumBus.disconnect() } catch { /* */ }
     try { this.drumCompressor.disconnect() } catch { /* */ }
+    try { this.drumParallelWet.disconnect() } catch { /* */ }
     try { this.melodyBus.disconnect() } catch { /* */ }
-    try { this.melodySplit.disconnect() } catch { /* */ }
+    try { this.textureSplit.disconnect() } catch { /* */ }
     try { this.haasDelay.disconnect() } catch { /* */ }
-    try { this.melodyMerge.disconnect() } catch { /* */ }
+    try { this.textureMerge.disconnect() } catch { /* */ }
     try { this.bandMaster.disconnect() } catch { /* */ }
 
     this.drumChannel.dispose()
@@ -238,9 +252,10 @@ export class MixEngine {
 
     this.drumBus.dispose()
     this.drumCompressor.dispose()
+    this.drumParallelWet.dispose()
     this.melodyBus.dispose()
-    this.melodySplit.dispose()
-    this.melodyMerge.dispose()
+    this.textureSplit.dispose()
+    this.textureMerge.dispose()
     this.haasDelay.dispose()
     this.bandMaster.dispose()
 

--- a/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
+++ b/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
@@ -236,3 +236,62 @@ for all of this: `fc2ed540`.
 - **Doubles trap** — improvisers must be called FROM the existing rebuild paths.
   If an implementation finds itself creating a new Part-scheduling pipeline or a
   second swing table, STOP: that's the anti-pattern this repo fights.
+
+---
+
+## 9. Producer-quality caps (2026-07-03) — continues this spec
+
+Full-pipeline audit after freeplay landed ("why isn't it producer level?").
+The note-writing layer was sound; the caps were downstream. All fixed on
+`claude/organism-producer-beats-r7o9a7`:
+
+**Delivery-chain bugs (the big ones):**
+1. **Open hats never fired in freeplay** — `resolveVoice` splits open/closed at
+   velocity 0.55; freeplay hats maxed at 0.48. Fixed two ways: the improviser
+   now writes deliberate open-hat accents (vel 0.68 on chosen off-beat 8ths),
+   and the kit resolves the voice from the PRE-duck pattern velocity so a
+   kick-duck can't flip an open hat closed (`trigger(..., voiceVelocity)`).
+2. **Double hat attenuation** — `rebuildPart` multiplied pattern velocities by
+   `hatCyclicPattern` [1.0, 0.4, …] on top of the improviser's own shaping
+   (0.22 × 0.4 → inaudible). Removed; pattern sources own velocity.
+3. **Linear velocity→gain** buried the feel layer. `velocityToGain()` in
+   SampledDrumKit: floor 0.12 + power curve 1.35 — ghosts audible, accents keep
+   contrast.
+4. **"Parallel compression" was serial** — drums+bass ran THROUGH the 4:1 bus
+   comp (no dry path): four compressors in series, no thwack, pumping 808.
+   MixEngine now wires true NY parallel: dry `drumBus → bandMaster` plus a
+   crushed copy (-24/6:1/3ms) blended at 0.45 underneath.
+5. **Blanket 18ms Haas** on melody+chords+texture comb-filtered everything in
+   mono. Haas now applies to texture only; melody/chords place via panners.
+6. **Sample truncation** — VOICE_DURATION cut kick tails at 0.65s / open hat at
+   0.5s. Lengthened (kick 1.1s, open hat 0.85s); closed hat stays 0.08s.
+7. **Level ceiling** — Flow capped drums at 0.78 with no makeup gain anywhere;
+   raised to 0.88 (master -9 dB + -0.3 dBFS WaveShaper ceiling absorb it).
+
+**Musical upgrades:**
+8. **2-bar kick cycle** — SKELETONS gained `kicksB`; bar B answers bar A
+   (identity genres — jersey club, reggaeton dembow, chill — keep A = B). The
+   1-bar kick loop ×4 was the strongest remaining "it's looped" signal.
+9. **Fill rotation** — snare-run / kick-stutter / cut (silence) / perc-run,
+   drawn per phrase, instead of the same ascending snare run forever.
+10. **Motif-driven 16th hat infill** — committed off-16th slots per section
+    (was a per-slot coin flip = noise, contradicting §4.2).
+11. **Groove template** — DrumGenerator's lazy-snare/hat-shuffle jitter was
+    `Math.random()` per event; now seeded per-slot offsets stable across bars
+    and rebuilds (MPC-style pocket), seeded per physics mode.
+12. **Snare+clap layering** — backbeat snares (vel ≥ 0.75) stack the clap at
+    0.55× under the snare; claps are layer-only, no more random round-robin
+    snare/clap alternation.
+13. **Key tuning** — new pure `pitchDetect.ts` (autocorrelation, 25–200 Hz,
+    tail-weighted, octave-error guard). Kicks retune onto the Conductor's key
+    root via playbackRate (≤ ±3 st, cached off-thread); Real808BassSampler
+    measures its sample's true fundamental and keys the sampler on the DETECTED
+    root instead of trusting `rootNote || 'C1'` metadata.
+
+**Deferred:** arrangement "moments" (pre-drop silence, risers, filter moves) —
+that's arrangement writing, a separate design; kick layering (sub+punch+top
+stacks) — needs curated layer-compatible sample sets.
+
+**Verification:** vitest green (freeplay + pitchDetect suites, 598 total),
+`npm run check` clean. WebEar capture + by-ear gate still required before this
+merges — same §6 rule as every phase.


### PR DESCRIPTION
Full-pipeline fixes for "why can't the Organism produce producer-level beats" — continues the 2026-07-02 freeplay spec (§9 added there documenting this phase).

## Delivery-chain bugs
- **Open hats never fired in freeplay** — velocity ceiling (0.48) never crossed the open/closed split (0.55). Improviser now writes open-hat accents; `SampledDrumKit.trigger` resolves the voice from the pre-duck pattern velocity so kick-ducking can't flip an open hat closed.
- **Double hat attenuation removed** — `rebuildPart` no longer multiplies pattern velocities by `hatCyclicPattern` on top of the improviser's own shaping.
- **`velocityToGain()`** — audibility floor + power curve replaces the linear velocity→gain that buried ghost notes and 16th infill.
- **True NY parallel compression** — the drum bus compressor was wired serial (no dry path); drums+bass ran through four compressors in series. Now: dry `drumBus → bandMaster` + crushed copy (−24 dB, 6:1, 3 ms) blended at 0.45.
- **Haas widening moved off melody/chords onto texture only** (mono comb-filter fix); melody/chords place via their channel panners.
- **Sample tails untruncated** (kick 0.65 s → 1.1 s, open hat 0.5 s → 0.85 s); Flow drum ceiling 0.78 → 0.88.

## Musical upgrades
- **2-bar kick skeletons** — `kicksB` answers bar A per genre (dembow/jersey/chill keep A = B by identity).
- **Fill rotation** — snare-run / kick-stutter / cut-silence / perc-run per phrase.
- **Motif-committed 16th hat infill** (was a per-slot coin flip).
- **Seeded groove template** — stable per-slot micro-timing (MPC-style pocket) instead of `Math.random()` per event.
- **Snare+clap layering** on backbeats; claps are layer-only.
- **Key tuning** — new pure `pitchDetect.ts` (autocorrelation, octave-error guard). Kicks retune to the Conductor key root via playbackRate (≤ ±3 st, off-thread, cached); `Real808BassSampler` keys on its measured fundamental instead of `rootNote || 'C1'` metadata.

## Verification
- 598 unit tests green (13 new: skeleton A/B, fill rotation, open-hat velocities, motif infill, pitch detection incl. sweep-kick and noise-rejection cases)
- `npm run check` and `npm run lint` clean
- ⚠️ WebEar/by-ear listen not yet done — owner chose to ship and verify in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_