### PR TITLE
feat(organism): melodic-side pass — 2-bar developing chord comps, chorus width, per-session variety salt

### DIFF
--- a/client/src/organism/generators/BassGenerator.ts
+++ b/client/src/organism/generators/BassGenerator.ts
@@ -16,7 +16,7 @@ import {
   getBassSwing,
 }                              from './patterns/BassPatternLibrary'
 import { buildFreeplayBassNotes } from './freeplay/BassImproviser'
-import { hashString, mulberry32 } from './freeplay/utils'
+import { hashString, mulberry32, SESSION_SALT } from './freeplay/utils'
 import type { HipHopSubGenre } from '../state/MusicalState'
 import { getLivePartStart, livePartStartOffset, msUntilTransportTime, quantizeGridTime } from './CompositionClock'
 // ChordProgressionBank is no longer a direct dependency — Bass reads its
@@ -773,7 +773,7 @@ export class BassGenerator extends GeneratorBase {
         sectionName: this.currentSectionName,
         motifSeed: seed,
         kickTimes16ths: this.kickAnchors,
-        rng: mulberry32(seed + this.freeplayPhraseCounter++),
+        rng: mulberry32(seed + SESSION_SALT + this.freeplayPhraseCounter++),
       })
     }
 

--- a/client/src/organism/generators/ChordGenerator.ts
+++ b/client/src/organism/generators/ChordGenerator.ts
@@ -6,7 +6,7 @@
 
 import * as Tone from 'tone'
 import { buildFreeplayCompPlan } from './freeplay/ChordImproviser'
-import { hashString, mulberry32 } from './freeplay/utils'
+import { hashString, mulberry32, SESSION_SALT } from './freeplay/utils'
 import type { LoopClip } from '@shared/loopPack'
 import { GeneratorBase }  from './GeneratorBase'
 import { GeneratorName }  from './types'
@@ -574,7 +574,12 @@ export class ChordGenerator extends GeneratorBase {
       const seed = hashString(`chord:${this.currentSectionName}`)
       const plan = buildFreeplayCompPlan({
         rootMidi: 60, chordIntervals: parsedCurrent.intervals ?? [0, 4, 7],
-        bars: 1,
+        // 2 bars: bar 1 states the comp motif, bar 2 develops it (variation +
+        // mid-bar push). The old 1-bar loop hit the SAME three slots every bar
+        // of the whole section — the "still repetitive" chord layer. Notes stay
+        // the current voicing throughout, so the 2-bar plan is chord-safe: a
+        // chord change rebuilds the part at the boundary exactly as before.
+        bars: 2,
         swing: this.currentSwing,
         subGenre: 'none',
         energy,
@@ -582,7 +587,7 @@ export class ChordGenerator extends GeneratorBase {
         sectionName: this.currentSectionName,
         motifSeed: seed,
         kickTimes16ths: [],
-        rng: mulberry32(seed + this.freeplayCallCounter++),
+        rng: mulberry32(seed + SESSION_SALT + this.freeplayCallCounter++),
       })
       for (const ev of plan) {
         const notes = ev.useNextVoicing
@@ -621,7 +626,9 @@ export class ChordGenerator extends GeneratorBase {
       }
     }
 
-    const loopBars = 1
+    // Freeplay comps a 2-bar statement/development cycle; authored behaviors
+    // keep their original 1-bar loop.
+    const loopBars = this.freeplayEnabled ? 2 : 1
 
     const quantizedEvents = events.map(event => ({
       ...event,

--- a/client/src/organism/generators/DrumGenerator.ts
+++ b/client/src/organism/generators/DrumGenerator.ts
@@ -12,7 +12,7 @@ import {
 }                              from './patterns/DrumPatternLibrary'
 import { getLivePartStart, livePartStartOffset, msUntilTransportTime, quantizeGridTime } from './CompositionClock'
 import { SampledDrumKit }       from './SampledDrumKit'
-import { mulberry32, hashString } from './freeplay/utils'
+import { mulberry32, hashString, SESSION_SALT } from './freeplay/utils'
 import type { PhysicsState }   from '../physics/types'
 import { OrganismMode }        from '../physics/types'
 import type { OrganismState }  from '../state/types'
@@ -232,7 +232,7 @@ export class DrumGenerator extends GeneratorBase {
   private grooveSnareLagMs:  number[] = []   // lazy-snare lag per beat (0..3)
 
   private buildGrooveTemplate(): void {
-    const rng = mulberry32(hashString(`groove:${this.currentPhysicsMode}`))
+    const rng = mulberry32(hashString(`groove:${this.currentPhysicsMode}`) + SESSION_SALT)
     this.grooveHatShiftPct = Array.from({ length: 16 }, (_, slot) =>
       slot % 2 === 1
         ? this.hatShuffleMinPct + rng() * (this.hatShuffleMaxPct - this.hatShuffleMinPct)

--- a/client/src/organism/generators/GeneratorOrchestrator.ts
+++ b/client/src/organism/generators/GeneratorOrchestrator.ts
@@ -31,7 +31,7 @@ import { GeneratorBase } from './GeneratorBase'
 import type { GeneratorEvent } from '../session/types'
 import type { MelodicLoopPlayer } from '../loops/MelodicLoopPlayer'
 import type { AceStemLayer } from '../loops/AceStemLayer'
-import { extractKickSlots, hashString, mulberry32 } from './freeplay/utils'
+import { extractKickSlots, hashString, mulberry32, SESSION_SALT } from './freeplay/utils'
 import { clearMotifs } from './freeplay/motif'
 import { buildFreeplayDrumHits } from './freeplay/DrumImproviser'
 import { clearCompCounters } from './freeplay/ChordImproviser'
@@ -1398,7 +1398,7 @@ export class GeneratorOrchestrator {
         sectionName: this.currentSectionName,
         motifSeed: seed,
         kickTimes16ths: [],
-        rng: mulberry32(seed + this.freeplayDrumCounter++),
+        rng: mulberry32(seed + SESSION_SALT + this.freeplayDrumCounter++),
       })
     } else {
       hits = buildSubGenrePattern(subGenre, variantIndex).hits

--- a/client/src/organism/generators/freeplay/ChordImproviser.ts
+++ b/client/src/organism/generators/freeplay/ChordImproviser.ts
@@ -11,22 +11,43 @@ export interface CompEvent {
   dur: string
   vel: number
   /** Anticipation: render with the NEXT chord's voicing (pickup into the change).
-   *  CURRENTLY NEVER SET: the comp Part loops 1 bar while the harmonic rhythm is
-   *  2 bars, so a baked-in anticipation fires a full bar early half the time —
-   *  the wrong chord's notes, measured as the user's "not in key" (2026-07-02).
+   *  CURRENTLY NEVER SET: the comp Part loops shorter than the harmonic rhythm
+   *  can guarantee, so a baked-in anticipation fires early with the wrong
+   *  chord's notes — measured as the user's "not in key" (2026-07-02).
    *  Re-enable only from a scheduler that knows the real chord boundary. */
   useNextVoicing?: boolean
 }
 
-// Per-section call counter → A-A-A'-A across successive 1-bar rebuilds.
+// Per-section call counter → A-A-A'-A across successive rebuilds.
 const compCounters = new Map<string, number>()
 
 const BACKBEAT = new Set([4, 12])
 
+// The mid-bar push slot — "and of 2" (slot 6). A syncopated stab there is the
+// keys-player push that makes comping feel intentional, and it is SAFE with the
+// current voicing (unlike a next-chord anticipation, it never lands on a
+// harmony boundary).
+const PUSH_SLOT = 6
+
+const clampVel = (v: number) => Math.min(0.7, Math.max(0.3, v))
+
+/**
+ * Multi-bar comp plan (ctx.bars, aligned to the part loop):
+ * bar 0 states the section's comp motif; the LAST bar develops it — one bounded
+ * variation plus (usually) a mid-bar push. A 1-bar request keeps the legacy
+ * behaviour: statement bars with a variation every 3rd rebuild.
+ */
 export function buildFreeplayCompPlan(ctx: FreeplayContext): CompEvent[] {
-  // Low energy: one pad, whole bar. Space is comping too.
+  const bars = Math.max(1, Math.floor(ctx.bars) || 1)
+
+  // Low energy: one pad per bar. Space is comping too — the re-attack each bar
+  // (slightly softer) keeps the pad breathing instead of freezing.
   if (ctx.energy < 0.4) {
-    return [{ time: swungTime(0, 0, ctx.swing), dur: '1m', vel: 0.5 }]
+    return Array.from({ length: bars }, (_, bar) => ({
+      time: swungTime(bar, 0, ctx.swing),
+      dur: '1m',
+      vel: bar === 0 ? 0.5 : 0.44,
+    }))
   }
 
   const key = `chord:${ctx.sectionName}:${ctx.subGenre}`
@@ -35,15 +56,25 @@ export function buildFreeplayCompPlan(ctx: FreeplayContext): CompEvent[] {
 
   const motif = getSectionMotif(key, ctx.rng, Math.min(ctx.density, 0.5), [0])
 
-  // Every 3rd bar gets the single bounded variation (A-A-A'), else the motif.
-  const mask: RhythmMotif = count % 3 === 0 ? varyMotif(motif, ctx.rng) : motif
-  const slots = mask.slots.filter(s => !BACKBEAT.has(s)).slice(0, ctx.energy > 0.7 ? 4 : 3)
+  const events: CompEvent[] = []
+  for (let bar = 0; bar < bars; bar++) {
+    const isDevBar = bars > 1 ? bar === bars - 1 : count % 3 === 0
+    const mask: RhythmMotif = isDevBar ? varyMotif(motif, ctx.rng) : motif
+    const slots = mask.slots.filter(s => !BACKBEAT.has(s)).slice(0, ctx.energy > 0.7 ? 4 : 3)
 
-  const events: CompEvent[] = slots.map((slot, i) => ({
-    time: swungTime(0, slot, ctx.swing),
-    dur: ctx.energy > 0.7 ? '8n' : slot === 0 ? '2n' : '4n',
-    vel: Math.min(0.7, Math.max(0.3, (slot === 0 ? 0.6 : 0.48) - i * 0.02)),
-  }))
+    slots.forEach((slot, i) => {
+      events.push({
+        time: swungTime(bar, slot, ctx.swing),
+        dur: ctx.energy > 0.7 ? '8n' : slot === 0 ? '2n' : '4n',
+        vel: clampVel((slot === 0 ? 0.6 : 0.48) - i * 0.02 + (isDevBar ? 0.04 : 0)),
+      })
+    })
+
+    // Development bar usually adds the mid-bar push (same voicing — safe).
+    if (isDevBar && bars > 1 && !slots.includes(PUSH_SLOT) && ctx.rng() < 0.8) {
+      events.push({ time: swungTime(bar, PUSH_SLOT, ctx.swing), dur: '8n', vel: 0.52 })
+    }
+  }
 
   return events
 }

--- a/client/src/organism/generators/freeplay/__tests__/ChordImproviser.test.ts
+++ b/client/src/organism/generators/freeplay/__tests__/ChordImproviser.test.ts
@@ -20,6 +20,8 @@ const slotOf = (t: string) => {
   return beat * 4 + Math.floor(sub)
 }
 
+const barOf = (t: string) => parseInt(t.split(':')[0], 10)
+
 describe('ChordImproviser', () => {
   beforeEach(() => { clearMotifs(); clearCompCounters() })
 
@@ -63,5 +65,39 @@ describe('ChordImproviser', () => {
       expect(ev.vel).toBeLessThanOrEqual(0.7)
       expect(ev.vel).toBeGreaterThanOrEqual(0.3)
     }
+  })
+
+  it('2-bar plan: bar 1 states the motif, bar 2 develops it (not an identical copy)', () => {
+    let developed = 0
+    for (let seed = 0; seed < 12; seed++) {
+      clearMotifs(); clearCompCounters()
+      const plan = buildFreeplayCompPlan(ctx({ bars: 2, rng: mulberry32(seed) }))
+      const barSlots = (bar: number) =>
+        plan.filter(e => barOf(e.time) === bar).map(e => slotOf(e.time)).sort((a, b) => a - b)
+      expect(barSlots(0).length).toBeGreaterThanOrEqual(1)
+      expect(barSlots(1).length).toBeGreaterThanOrEqual(1)
+      if (JSON.stringify(barSlots(0)) !== JSON.stringify(barSlots(1))) developed++
+    }
+    // development is probabilistic per seed but must be the norm
+    expect(developed).toBeGreaterThan(6)
+  })
+
+  it('2-bar plan still avoids the backbeat and never anticipates the next voicing', () => {
+    for (let seed = 0; seed < 10; seed++) {
+      clearMotifs(); clearCompCounters()
+      const plan = buildFreeplayCompPlan(ctx({ bars: 2, energy: 0.9, rng: mulberry32(seed) }))
+      for (const ev of plan) {
+        expect([4, 12]).not.toContain(slotOf(ev.time))
+        expect(ev.useNextVoicing).toBeUndefined()
+      }
+    }
+  })
+
+  it('low-energy 2-bar plan pads both bars (softer re-attack, no dead second bar)', () => {
+    const plan = buildFreeplayCompPlan(ctx({ bars: 2, energy: 0.2 }))
+    expect(plan).toHaveLength(2)
+    expect(barOf(plan[0].time)).toBe(0)
+    expect(barOf(plan[1].time)).toBe(1)
+    expect(plan[1].vel).toBeLessThan(plan[0].vel)
   })
 })

--- a/client/src/organism/generators/freeplay/utils.ts
+++ b/client/src/organism/generators/freeplay/utils.ts
@@ -1,5 +1,15 @@
 // Pure helpers for the freeplay improvisers. NO tone imports (testability).
 
+/**
+ * Per-app-load salt mixed into every freeplay seed at the CALL SITES (never
+ * inside the pure improvisers — tests pass explicit rngs and stay exact).
+ * Without it, seeds like hashString('drums:verse:boom-bap') + a counter
+ * starting at 0 made every fresh session improvise the IDENTICAL beat for a
+ * given preset — "improvised" in name, hardcoded in effect. Within a session
+ * the salt is constant, so section-motif stability is untouched.
+ */
+export const SESSION_SALT: number = Math.floor(Math.random() * 0x7fffffff)
+
 /** Deterministic PRNG — same seed, same stream. */
 export function mulberry32(seed: number): () => number {
   let a = seed >>> 0

--- a/client/src/organism/mix/MixEngine.ts
+++ b/client/src/organism/mix/MixEngine.ts
@@ -29,6 +29,7 @@ export class MixEngine {
   readonly drumCompressor:  Tone.Compressor
   readonly drumParallelWet: Tone.Gain
   readonly melodyBus:       Tone.Gain
+  readonly melodyChorus:    Tone.Chorus
   readonly textureSplit:    Tone.Split
   readonly textureMerge:    Tone.Merge
   readonly haasDelay:       Tone.Delay
@@ -76,14 +77,24 @@ export class MixEngine {
     this.drumCompressor.connect(this.drumParallelWet)
     this.drumParallelWet.connect(this.bandMaster)
 
-    // 3. Melody Bus (Keys, Chords) — DIRECT to the band master. The blanket
-    // 18ms Haas delay that used to sit on this whole bus comb-filtered every
-    // melodic element in mono and smeared the top end; placement now comes
-    // from the per-channel panners (melody +0.15, chord -0.10).
+    // 3. Melody Bus (Keys, Chords) → subtle stereo chorus → band master.
+    // History: an 18ms static Haas delay sat here (mono comb-filter, smeared
+    // top); removing it outright left keys/lead a dry mono blob in the centre —
+    // "the melodic side sticks out" (by-ear, 2026-07-03). A slow, mostly-dry
+    // chorus is the producer-keys width move: modulated so mono sums shimmer
+    // instead of combing, wet kept low so the dry attack still leads.
     this.melodyBus = new Tone.Gain(1)
+    this.melodyChorus = new Tone.Chorus({
+      frequency: 0.5,   // slow drift, not vibrato
+      delayTime: 3.5,   // ms — width territory, not slapback
+      depth: 0.35,
+      spread: 180,      // full L/R spread of the modulated copies
+      wet: 0.25,
+    }).start()
     this.melodyChannel.output.connect(this.melodyBus)
     this.chordChannel.output.connect(this.melodyBus)
-    this.melodyBus.connect(this.bandMaster)
+    this.melodyBus.connect(this.melodyChorus)
+    this.melodyChorus.connect(this.bandMaster)
 
     // 4. Texture keeps the Haas widening — pads/atmosphere are exactly where
     // wide-and-diffuse is wanted, and the channel is quiet (-14 dB) so the
@@ -239,6 +250,7 @@ export class MixEngine {
     try { this.drumCompressor.disconnect() } catch { /* */ }
     try { this.drumParallelWet.disconnect() } catch { /* */ }
     try { this.melodyBus.disconnect() } catch { /* */ }
+    try { this.melodyChorus.disconnect() } catch { /* */ }
     try { this.textureSplit.disconnect() } catch { /* */ }
     try { this.haasDelay.disconnect() } catch { /* */ }
     try { this.textureMerge.disconnect() } catch { /* */ }
@@ -254,6 +266,7 @@ export class MixEngine {
     this.drumCompressor.dispose()
     this.drumParallelWet.dispose()
     this.melodyBus.dispose()
+    this.melodyChorus.dispose()
     this.textureSplit.dispose()
     this.textureMerge.dispose()
     this.haasDelay.dispose()

--- a/client/src/organism/mix/__tests__/__mocks__/toneMixMock.ts
+++ b/client/src/organism/mix/__tests__/__mocks__/toneMixMock.ts
@@ -67,6 +67,13 @@ export function createMixToneMock() {
     Delay: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
       return Object.assign(this, makeDisposable())
     }),
+    Chorus: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      return Object.assign(this, {
+        ...makeDisposable(),
+        start: vi.fn().mockReturnThis(),
+        wet: { value: 0.25 },
+      })
+    }),
     dbToGain: vi.fn().mockImplementation((db: number) => Math.pow(10, db / 20)),
     // SharedMasterBus uses these to wire its chain into the hardware destination
     // and to reroute Tone.Destination through itself. Tests only need them to

--- a/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
+++ b/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
@@ -295,3 +295,29 @@ stacks) — needs curated layer-compatible sample sets.
 **Verification:** vitest green (freeplay + pitchDetect suites, 598 total),
 `npm run check` clean. WebEar capture + by-ear gate still required before this
 merges — same §6 rule as every phase.
+
+---
+
+## 10. Melodic-side pass + session variety (2026-07-03, same day)
+
+By-ear verdict on §9 in production: "almost but not there" — mix/loudness feel
++ still repetitive, **melodic side worst**. Second pass:
+
+1. **Chord comping was a 1-bar loop** hitting the same 3 slots every bar of a
+   section. `buildFreeplayCompPlan` now plans multi-bar: bar 1 states the
+   section motif, last bar develops it (bounded variation + mid-bar push on the
+   and-of-2, slot 6 — same-voicing, chord-boundary-safe unlike the removed
+   next-voicing anticipation). ChordGenerator freeplay loops 2 bars.
+2. **Width restored properly** — §9 removed the melody-bus Haas outright,
+   leaving keys/lead a dry mono blob in the centre. A slow mostly-dry stereo
+   chorus (0.5 Hz / 3.5 ms / depth 0.35 / wet 0.25, spread 180) now sits on the
+   melody+chord bus: modulated width, no static mono comb.
+3. **SESSION_SALT** (`freeplay/utils.ts`) — every freeplay seed was a
+   deterministic string hash + a counter starting at 0, so each fresh app load
+   improvised the IDENTICAL beat per preset. A random per-load salt is mixed in
+   at every call site (drums/bass/chords/groove template). Purity preserved:
+   the salt never enters the improvisers, tests pass explicit rngs.
+
+Still open if the melodic side needs more: chord instrument choice per
+sub-genre (GM soundfont defaults read dated), melody/chord call-and-response,
+arrangement moments (§9 deferred list).


### PR DESCRIPTION
Follow-up to #24 after the by-ear verdict ("almost but not there" — mix feel + still repetitive, melodic side worst). Spec §10 documents this pass.

- **2-bar developing chord comps** — the comp plan was one bar looped, hitting the same 3 slots every bar of a section. Now bar 1 states the section motif and bar 2 develops it (bounded variation + a same-voicing push on the and-of-2, which is chord-boundary-safe unlike the removed next-voicing anticipation).
- **Stereo chorus on the melody+chord bus** (0.5 Hz / 3.5 ms / wet 0.25) — restores the width lost when #24 removed the static Haas, without the mono comb-filter.
- **`SESSION_SALT`** — freeplay seeds were deterministic string hashes + counters starting at 0, so every fresh app load improvised the *identical* beat per preset. A random per-load salt now mixes into every freeplay call site (drums / bass / chords / groove template). The improvisers stay pure; tests pass explicit rngs.

593 unit tests green (4 new 2-bar comp contracts), `tsc` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_