### PR TITLE
feat(organism): freeplay seed contract — new beat every start, reproducible when pinned

### DIFF
--- a/client/src/organism/generators/BassGenerator.ts
+++ b/client/src/organism/generators/BassGenerator.ts
@@ -16,7 +16,7 @@ import {
   getBassSwing,
 }                              from './patterns/BassPatternLibrary'
 import { buildFreeplayBassNotes } from './freeplay/BassImproviser'
-import { hashString, mulberry32, SESSION_SALT } from './freeplay/utils'
+import { hashString, mulberry32, getSessionSalt } from './freeplay/utils'
 import type { HipHopSubGenre } from '../state/MusicalState'
 import { getLivePartStart, livePartStartOffset, msUntilTransportTime, quantizeGridTime } from './CompositionClock'
 // ChordProgressionBank is no longer a direct dependency — Bass reads its
@@ -70,6 +70,9 @@ export class BassGenerator extends GeneratorBase {
   private chordIntervals: number[] = [0, 3, 7]
   private kickAnchors: number[] = []
   private freeplayPhraseCounter = 0
+
+  /** Zeroed on every organism start so a pinned freeplay seed replays exactly. */
+  resetFreeplayCounter(): void { this.freeplayPhraseCounter = 0 }
 
   private unsubscribeConductor: (() => void) | null = null
   // Set by the Conductor's onChordChange listener; consumed on the next
@@ -773,7 +776,7 @@ export class BassGenerator extends GeneratorBase {
         sectionName: this.currentSectionName,
         motifSeed: seed,
         kickTimes16ths: this.kickAnchors,
-        rng: mulberry32(seed + SESSION_SALT + this.freeplayPhraseCounter++),
+        rng: mulberry32(seed + getSessionSalt() + this.freeplayPhraseCounter++),
       })
     }
 

--- a/client/src/organism/generators/ChordGenerator.ts
+++ b/client/src/organism/generators/ChordGenerator.ts
@@ -6,7 +6,7 @@
 
 import * as Tone from 'tone'
 import { buildFreeplayCompPlan } from './freeplay/ChordImproviser'
-import { hashString, mulberry32, SESSION_SALT } from './freeplay/utils'
+import { hashString, mulberry32, getSessionSalt } from './freeplay/utils'
 import type { LoopClip } from '@shared/loopPack'
 import { GeneratorBase }  from './GeneratorBase'
 import { GeneratorName }  from './types'
@@ -90,6 +90,9 @@ export class ChordGenerator extends GeneratorBase {
   // ── Freeplay (spec 2026-07-02) ── comp plans instead of a fixed technique.
   private freeplayEnabled = true
   private freeplayCallCounter = 0
+
+  /** Zeroed on every organism start so a pinned freeplay seed replays exactly. */
+  resetFreeplayCounter(): void { this.freeplayCallCounter = 0 }
 
   // Tracks whether the technique was explicitly set by a warm-up phrase or
   // external caller. When false, mode changes auto-update the technique to
@@ -587,7 +590,7 @@ export class ChordGenerator extends GeneratorBase {
         sectionName: this.currentSectionName,
         motifSeed: seed,
         kickTimes16ths: [],
-        rng: mulberry32(seed + SESSION_SALT + this.freeplayCallCounter++),
+        rng: mulberry32(seed + getSessionSalt() + this.freeplayCallCounter++),
       })
       for (const ev of plan) {
         const notes = ev.useNextVoicing

--- a/client/src/organism/generators/DrumGenerator.ts
+++ b/client/src/organism/generators/DrumGenerator.ts
@@ -12,7 +12,7 @@ import {
 }                              from './patterns/DrumPatternLibrary'
 import { getLivePartStart, livePartStartOffset, msUntilTransportTime, quantizeGridTime } from './CompositionClock'
 import { SampledDrumKit }       from './SampledDrumKit'
-import { mulberry32, hashString, SESSION_SALT } from './freeplay/utils'
+import { mulberry32, hashString, getSessionSalt } from './freeplay/utils'
 import type { PhysicsState }   from '../physics/types'
 import { OrganismMode }        from '../physics/types'
 import type { OrganismState }  from '../state/types'
@@ -232,7 +232,7 @@ export class DrumGenerator extends GeneratorBase {
   private grooveSnareLagMs:  number[] = []   // lazy-snare lag per beat (0..3)
 
   private buildGrooveTemplate(): void {
-    const rng = mulberry32(hashString(`groove:${this.currentPhysicsMode}`) + SESSION_SALT)
+    const rng = mulberry32(hashString(`groove:${this.currentPhysicsMode}`) + getSessionSalt())
     this.grooveHatShiftPct = Array.from({ length: 16 }, (_, slot) =>
       slot % 2 === 1
         ? this.hatShuffleMinPct + rng() * (this.hatShuffleMaxPct - this.hatShuffleMinPct)

--- a/client/src/organism/generators/GeneratorOrchestrator.ts
+++ b/client/src/organism/generators/GeneratorOrchestrator.ts
@@ -31,7 +31,7 @@ import { GeneratorBase } from './GeneratorBase'
 import type { GeneratorEvent } from '../session/types'
 import type { MelodicLoopPlayer } from '../loops/MelodicLoopPlayer'
 import type { AceStemLayer } from '../loops/AceStemLayer'
-import { extractKickSlots, hashString, mulberry32, SESSION_SALT } from './freeplay/utils'
+import { extractKickSlots, hashString, mulberry32, getSessionSalt, rerollSessionSalt } from './freeplay/utils'
 import { clearMotifs } from './freeplay/motif'
 import { buildFreeplayDrumHits } from './freeplay/DrumImproviser'
 import { clearCompCounters } from './freeplay/ChordImproviser'
@@ -442,6 +442,21 @@ export class GeneratorOrchestrator {
     this.chord.setSwing(startSwing)
     this.melody.setSwing(startSwing)
 
+    // Per-start variety: fresh freeplay salt (a NEW beat every start — unless
+    // the user pinned a seed via setFreeplaySeed), fresh motifs, and counters
+    // back to zero so a pinned seed reproduces the beat EXACTLY. Must run
+    // BEFORE the initial drum pattern below, or bar 1 plays the old session's
+    // motif and self-heals a rebuild later.
+    const freeplaySeed = rerollSessionSalt()
+    clearMotifs()
+    clearCompCounters()
+    this.freeplayDrumCounter = 0
+    this.chord.resetFreeplayCounter()
+    this.bass.resetFreeplayCounter()
+    console.info(
+      `[Organism] freeplay seed ${freeplaySeed} — run setFreeplaySeed(${freeplaySeed}) in the console then restart to replay this beat; setFreeplaySeed(null) returns to random`,
+    )
+
     // Load the initial drum pattern explicitly. With Song Mode (arrangement)
     // off there are no section entries to load it, and onSubGenreChange only
     // fires on a CHANGE — a cold start whose sub-genre matched the director's
@@ -449,10 +464,6 @@ export class GeneratorOrchestrator {
     if (this.drumEnabled) {
       this.drum.loadGeneratedPattern(this.buildDrumHits(startSubGenre, this.director.getState().drums.variantIndex), true)
     }
-
-    // Per-start variety: each session commits fresh freeplay motifs.
-    clearMotifs()
-    clearCompCounters()
 
     // Reset the progressive intro counter so every fresh start replays the
     // instrument-stacking sequence from bar 0.
@@ -1398,7 +1409,7 @@ export class GeneratorOrchestrator {
         sectionName: this.currentSectionName,
         motifSeed: seed,
         kickTimes16ths: [],
-        rng: mulberry32(seed + SESSION_SALT + this.freeplayDrumCounter++),
+        rng: mulberry32(seed + getSessionSalt() + this.freeplayDrumCounter++),
       })
     } else {
       hits = buildSubGenrePattern(subGenre, variantIndex).hits

--- a/client/src/organism/generators/freeplay/utils.ts
+++ b/client/src/organism/generators/freeplay/utils.ts
@@ -1,14 +1,43 @@
 // Pure helpers for the freeplay improvisers. NO tone imports (testability).
 
 /**
- * Per-app-load salt mixed into every freeplay seed at the CALL SITES (never
+ * Freeplay seed/salt — mixed into every freeplay seed at the CALL SITES (never
  * inside the pure improvisers — tests pass explicit rngs and stay exact).
- * Without it, seeds like hashString('drums:verse:boom-bap') + a counter
- * starting at 0 made every fresh session improvise the IDENTICAL beat for a
- * given preset — "improvised" in name, hardcoded in effect. Within a session
- * the salt is constant, so section-motif stability is untouched.
+ *
+ * Contract (the user's rule): every organism start improvises a DIFFERENT beat
+ * for the same preset, UNLESS a seed is pinned — then the beat reproduces
+ * exactly. Without this, seeds like hashString('drums:verse:boom-bap') + a
+ * counter starting at 0 made every start play the identical "improvised" beat.
+ * Within one run the salt is constant, so section-motif stability is untouched.
  */
-export const SESSION_SALT: number = Math.floor(Math.random() * 0x7fffffff)
+const randomSalt = () => Math.floor(Math.random() * 0x7fffffff)
+
+let pinnedSeed: number | null = null
+let sessionSalt: number = randomSalt()
+
+export function getSessionSalt(): number {
+  return sessionSalt
+}
+
+/** Pin the freeplay seed so the same preset replays the same beat; pass null
+ *  to unpin and return to a-new-beat-every-start. Returns the active salt. */
+export function setFreeplaySeed(seed: number | null): number {
+  pinnedSeed = seed
+  sessionSalt = seed === null ? randomSalt() : Math.floor(Math.abs(seed)) % 0x7fffffff
+  return sessionSalt
+}
+
+/** Called once per organism start: fresh salt, unless a seed is pinned. */
+export function rerollSessionSalt(): number {
+  if (pinnedSeed === null) sessionSalt = randomSalt()
+  return sessionSalt
+}
+
+// Console access for reproducing a beat you like: the orchestrator logs the
+// active seed on every start; `setFreeplaySeed(<that number>)` pins it.
+if (typeof window !== 'undefined') {
+  ;(window as unknown as Record<string, unknown>).setFreeplaySeed = setFreeplaySeed
+}
 
 /** Deterministic PRNG — same seed, same stream. */
 export function mulberry32(seed: number): () => number {

--- a/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
+++ b/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
@@ -312,11 +312,16 @@ By-ear verdict on §9 in production: "almost but not there" — mix/loudness fee
    leaving keys/lead a dry mono blob in the centre. A slow mostly-dry stereo
    chorus (0.5 Hz / 3.5 ms / depth 0.35 / wet 0.25, spread 180) now sits on the
    melody+chord bus: modulated width, no static mono comb.
-3. **SESSION_SALT** (`freeplay/utils.ts`) — every freeplay seed was a
-   deterministic string hash + a counter starting at 0, so each fresh app load
-   improvised the IDENTICAL beat per preset. A random per-load salt is mixed in
-   at every call site (drums/bass/chords/groove template). Purity preserved:
-   the salt never enters the improvisers, tests pass explicit rngs.
+3. **Freeplay seed contract** (`freeplay/utils.ts`) — user's rule, verbatim:
+   *"each time I use that preset it should be different — unless I have a seed."*
+   Every freeplay seed was a deterministic string hash + a counter starting at
+   0, so each fresh app load improvised the IDENTICAL beat per preset.
+   Now: `rerollSessionSalt()` draws a fresh random salt on EVERY organism
+   start (new beat per start, not just per page load), all freeplay counters
+   zero on start, and `setFreeplaySeed(n)` (exported + attached to `window`,
+   seed logged to console on each start) pins the salt so the same preset
+   replays the same beat exactly; `setFreeplaySeed(null)` unpins. Purity
+   preserved: the salt never enters the improvisers, tests pass explicit rngs.
 
 Still open if the melodic side needs more: chord instrument choice per
 sub-genre (GM soundfont defaults read dated), melody/chord call-and-response,


### PR DESCRIPTION
Implements the owner's rule verbatim: *"each time I use that preset it should be different — unless I have a seed."*

- `rerollSessionSalt()` draws a fresh random salt on **every organism start** — previously the salt was fixed per page load, so restarting a preset in the same session could replay familiar material.
- All freeplay counters (drums/chords/bass) zero on start, and the reroll + motif clears now run **before** the initial drum pattern build (bar 1 used to play the previous session's motif until the first rebuild self-healed).
- `setFreeplaySeed(n)` pins the salt so the same preset replays the same beat exactly; `setFreeplaySeed(null)` unpins. Attached to `window`, and the active seed is logged to the console on every start so a beat you like can be copied and replayed.
- Improvisers stay pure — the salt only mixes in at call sites; tests pass explicit rngs.

593 unit tests green, `tsc` clean. Spec §10 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_