### PR TITLE
feat(organism): Beat Seed panel + band awareness (chords hear the kick, phase-locked comping)

### DIFF
--- a/client/src/features/organism/OrganismCommandCenter.tsx
+++ b/client/src/features/organism/OrganismCommandCenter.tsx
@@ -21,6 +21,7 @@ import { OState } from '../../organism/state/types'
 import { useStudioStore } from '../../stores/useStudioStore'
 import { INSTRUMENT_PERFORMERS } from '../../organism/performers'
 import type { InstrumentPerformerId, PerformerRole } from '../../organism/performers'
+import { getSessionSalt, setFreeplaySeed, isSeedPinned } from '../../organism/generators/freeplay/utils'
 
 // ── Web Speech API local typings ───────────────────────────────────────────
 // The browser's SpeechRecognition is experimental — TS lib doesn't always
@@ -552,6 +553,38 @@ export function OrganismCommandCenter() {
     setDrumFreeplayLocal(next)
     orchestrator?.setDrumFreeplay(next)
   }, [drumFreeplay, orchestrator])
+
+  // ── Beat seed — every start improvises a new beat unless pinned ─────────
+  const [beatSeed,   setBeatSeed]   = useState<number>(() => getSessionSalt())
+  const [seedPinned, setSeedPinned] = useState<boolean>(() => isSeedPinned())
+  const [seedInput,  setSeedInput]  = useState('')
+
+  useEffect(() => {
+    // Orchestrator dispatches the active seed on every organism start.
+    const onSeed = (e: Event) => setBeatSeed((e as CustomEvent<{ seed: number }>).detail.seed)
+    window.addEventListener('organism:freeplay-seed', onSeed)
+    return () => window.removeEventListener('organism:freeplay-seed', onSeed)
+  }, [])
+
+  const toggleSeedPin = useCallback(() => {
+    if (seedPinned) {
+      setFreeplaySeed(null)
+      setSeedPinned(false)
+    } else {
+      // Pin the beat that's playing right now — next start replays it.
+      setFreeplaySeed(beatSeed)
+      setSeedPinned(true)
+    }
+  }, [seedPinned, beatSeed])
+
+  const applySeedInput = useCallback(() => {
+    const n = parseInt(seedInput.trim(), 10)
+    if (!Number.isFinite(n)) return
+    const applied = setFreeplaySeed(n)
+    setBeatSeed(applied)
+    setSeedPinned(true)
+    setSeedInput('')
+  }, [seedInput])
 
   const resetChordTech = useCallback(() => {
     orchestrator?.resetChordTechniqueOverride()
@@ -1888,6 +1921,72 @@ export function OrganismCommandCenter() {
               <SliderRow label="Hat density"  value={hatDensity}   onChange={setHatDensity}   color={C.purple} />
               <SliderRow label="Kick vel."    value={kickVelocity} onChange={setKickVelocity} color='#f472b6' />
               <SliderRow label="Drums vol."   value={drumsVolume}  onChange={setDrumsVolume}  color='#fb923c' />
+            </div>
+          </div>
+
+          {/* Beat seed — every start improvises a new beat unless pinned */}
+          <div style={{
+            padding: '10px 14px 8px',
+            borderBottom: `0.5px solid ${C.border}`,
+            flexShrink: 0,
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ ...label11, flex: 1 }}>🎲 Beat seed</span>
+              <span
+                style={{
+                  fontFamily: 'ui-monospace, monospace', fontSize: 10,
+                  color: seedPinned ? C.amber : C.text2,
+                }}
+                title="The seed behind the current beat — pin it to replay this beat on every start"
+              >
+                {beatSeed}
+              </span>
+              <button
+                onClick={toggleSeedPin}
+                style={{
+                  padding: '2px 8px', borderRadius: 999, fontSize: 9, fontWeight: 600,
+                  cursor: 'pointer', letterSpacing: '0.05em',
+                  border: seedPinned ? `1px solid ${C.amber}55` : `1px solid rgba(100,116,139,0.2)`,
+                  background: seedPinned ? `${C.amber}18` : 'transparent',
+                  color: seedPinned ? C.amber : C.text3,
+                }}
+                title={seedPinned
+                  ? 'Pinned: every start replays this exact beat — click for a new beat each start'
+                  : 'Random: every start improvises a new beat — click to keep this one'}
+              >
+                {seedPinned ? '🔒 PINNED' : '🔓 RANDOM'}
+              </button>
+            </div>
+            <div style={{ display: 'flex', gap: 6, marginTop: 6, alignItems: 'center' }}>
+              <input
+                value={seedInput}
+                onChange={(e) => setSeedInput(e.target.value.replace(/[^0-9]/g, ''))}
+                onKeyDown={(e) => { if (e.key === 'Enter') applySeedInput() }}
+                placeholder="enter a seed to replay a beat…"
+                inputMode="numeric"
+                style={{
+                  flex: 1, minWidth: 0, padding: '3px 8px', borderRadius: 6,
+                  fontSize: 10, fontFamily: 'ui-monospace, monospace',
+                  border: `1px solid ${C.border2}`, background: 'transparent',
+                  color: C.text, outline: 'none',
+                }}
+              />
+              <button
+                onClick={applySeedInput}
+                disabled={!seedInput.trim()}
+                style={{
+                  padding: '3px 10px', borderRadius: 6, fontSize: 10, fontWeight: 600,
+                  border: `1px solid ${seedInput.trim() ? C.cyan + '55' : C.border2}`,
+                  background: seedInput.trim() ? `${C.cyan}18` : 'transparent',
+                  color: seedInput.trim() ? C.cyan : C.text3,
+                  cursor: seedInput.trim() ? 'pointer' : 'default',
+                }}
+              >SET</button>
+            </div>
+            <div style={{ fontSize: 9, color: C.text3, marginTop: 5, lineHeight: 1.4 }}>
+              {seedPinned
+                ? 'Pinned — restart the preset to replay this exact beat. Unpin for a fresh one every start.'
+                : 'New beat on every start. Like this one? Pin it (applies from the next start).'}
             </div>
           </div>
 

--- a/client/src/organism/generators/ChordGenerator.ts
+++ b/client/src/organism/generators/ChordGenerator.ts
@@ -20,7 +20,7 @@ import { createSoundfontSampler, createMultisampleSampler, type LoadableSampler 
 import { getRealInstrumentNotes } from '../instruments/realInstruments'
 import { getTechnique, DEFAULT_TECHNIQUE_ID, defaultTechniqueForMode } from '../techniques/library'
 import type { TechniqueContext } from '../techniques/types'
-import { getLivePartStart, msUntilTransportTime, quantizeGridTime } from './CompositionClock'
+import { getLivePartStart, livePartStartOffset, msUntilTransportTime, quantizeGridTime } from './CompositionClock'
 import {
   conformChordToInstrument,
   selectInstrumentPerformer,
@@ -93,6 +93,15 @@ export class ChordGenerator extends GeneratorBase {
 
   /** Zeroed on every organism start so a pinned freeplay seed replays exactly. */
   resetFreeplayCounter(): void { this.freeplayCallCounter = 0 }
+
+  // Kick onset slots from the current drum pattern (absolute 16ths), pushed by
+  // the orchestrator after every drum rebuild — same channel the bass uses.
+  // Freeplay comping reads these to sit in the pockets BETWEEN the kicks.
+  private kickAnchors: number[] = []
+
+  setKickAnchors(slots: number[]): void {
+    this.kickAnchors = [...slots]
+  }
 
   // Tracks whether the technique was explicitly set by a warm-up phrase or
   // external caller. When false, mode changes auto-update the technique to
@@ -589,7 +598,7 @@ export class ChordGenerator extends GeneratorBase {
         density: energy,
         sectionName: this.currentSectionName,
         motifSeed: seed,
-        kickTimes16ths: [],
+        kickTimes16ths: this.kickAnchors,
         rng: mulberry32(seed + getSessionSalt() + this.freeplayCallCounter++),
       })
       for (const ev of plan) {
@@ -737,7 +746,11 @@ export class ChordGenerator extends GeneratorBase {
 
     this.part.loop = true
     this.part.loopEnd = `${loopBars}m`
-    this.part.start(startAt)
+    // Phase-aligned like drums/bass: the 2-bar statement/development cycle
+    // stays locked to the band's bar count, so the development bar (with its
+    // push) consistently answers the drums' bar-B kicks instead of drifting
+    // to whichever bar the rebuild happened on.
+    this.part.start(startAt, livePartStartOffset(startAt, loopBars))
     this.hasStartedPlayback = true
     return true
   }

--- a/client/src/organism/generators/GeneratorOrchestrator.ts
+++ b/client/src/organism/generators/GeneratorOrchestrator.ts
@@ -1393,7 +1393,9 @@ export class GeneratorOrchestrator {
       velocitySpread: 0.04,
     })
     this.drum.loadGeneratedPattern(mutated)
-    this.bass.setKickAnchors(extractKickSlots(mutated))
+    const anchors = extractKickSlots(mutated)
+    this.bass.setKickAnchors(anchors)
+    this.chord.setKickAnchors(anchors)
   }
 
   /** ONE drum-pattern source: freeplay improviser (default) or the authored
@@ -1418,7 +1420,11 @@ export class GeneratorOrchestrator {
     } else {
       hits = buildSubGenrePattern(subGenre, variantIndex).hits
     }
-    this.bass.setKickAnchors(extractKickSlots(hits))
+    // Rhythm-section glue: BOTH followers hear the same kick. Bass locks its
+    // onsets to it; chords comp in the pockets BETWEEN the kicks.
+    const anchors = extractKickSlots(hits)
+    this.bass.setKickAnchors(anchors)
+    this.chord.setKickAnchors(anchors)
     return hits
   }
 

--- a/client/src/organism/generators/GeneratorOrchestrator.ts
+++ b/client/src/organism/generators/GeneratorOrchestrator.ts
@@ -456,6 +456,10 @@ export class GeneratorOrchestrator {
     console.info(
       `[Organism] freeplay seed ${freeplaySeed} — run setFreeplaySeed(${freeplaySeed}) in the console then restart to replay this beat; setFreeplaySeed(null) returns to random`,
     )
+    // Let the Command Center's Beat Seed display track the active seed.
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('organism:freeplay-seed', { detail: { seed: freeplaySeed } }))
+    }
 
     // Load the initial drum pattern explicitly. With Song Mode (arrangement)
     // off there are no section entries to load it, and onSubGenreChange only

--- a/client/src/organism/generators/freeplay/ChordImproviser.ts
+++ b/client/src/organism/generators/freeplay/ChordImproviser.ts
@@ -56,11 +56,21 @@ export function buildFreeplayCompPlan(ctx: FreeplayContext): CompEvent[] {
 
   const motif = getSectionMotif(key, ctx.rng, Math.min(ctx.density, 0.5), [0])
 
+  // Band awareness: the drum pattern's kick slots (pushed by the orchestrator,
+  // same channel the bass uses). A keys player comps in the pockets BETWEEN
+  // the kicks — doubling a syncopated kick just thickens it into mud. The
+  // downbeat is exempt: chord + kick arriving together on beat 1 is the
+  // head-nod, not a collision.
+  const kickSet = new Set(ctx.kickTimes16ths.map(s => ((Math.floor(s) % 16) + 16) % 16))
+  const collides = (slot: number) => slot !== 0 && kickSet.has(slot)
+
   const events: CompEvent[] = []
   for (let bar = 0; bar < bars; bar++) {
     const isDevBar = bars > 1 ? bar === bars - 1 : count % 3 === 0
     const mask: RhythmMotif = isDevBar ? varyMotif(motif, ctx.rng) : motif
-    const slots = mask.slots.filter(s => !BACKBEAT.has(s)).slice(0, ctx.energy > 0.7 ? 4 : 3)
+    const slots = mask.slots
+      .filter(s => !BACKBEAT.has(s) && !collides(s))
+      .slice(0, ctx.energy > 0.7 ? 4 : 3)
 
     slots.forEach((slot, i) => {
       events.push({
@@ -71,9 +81,20 @@ export function buildFreeplayCompPlan(ctx: FreeplayContext): CompEvent[] {
     })
 
     // Development bar usually adds the mid-bar push (same voicing — safe).
-    if (isDevBar && bars > 1 && !slots.includes(PUSH_SLOT) && ctx.rng() < 0.8) {
-      events.push({ time: swungTime(bar, PUSH_SLOT, ctx.swing), dur: '8n', vel: 0.52 })
+    // The push also dodges the kick: try the and-of-2 first, then neighbours.
+    if (isDevBar && bars > 1 && ctx.rng() < 0.8) {
+      const pushSlot = [PUSH_SLOT, PUSH_SLOT + 1, PUSH_SLOT - 1]
+        .find(s => !collides(s) && !BACKBEAT.has(s) && !slots.includes(s))
+      if (pushSlot !== undefined) {
+        events.push({ time: swungTime(bar, pushSlot, ctx.swing), dur: '8n', vel: 0.52 })
+      }
     }
+  }
+
+  // Kick-heavy patterns can filter a sparse motif to nothing — always leave at
+  // least the downbeat anchor so the harmony never vanishes for a whole cycle.
+  if (events.length === 0) {
+    events.push({ time: swungTime(0, 0, ctx.swing), dur: '2n', vel: 0.55 })
   }
 
   return events

--- a/client/src/organism/generators/freeplay/__tests__/ChordImproviser.test.ts
+++ b/client/src/organism/generators/freeplay/__tests__/ChordImproviser.test.ts
@@ -93,6 +93,28 @@ describe('ChordImproviser', () => {
     }
   })
 
+  it('comps in the pockets BETWEEN the kicks — never doubles a syncopated kick slot', () => {
+    // Boom-bap-ish kick pattern across 4 bars: slots 0, 6, 10 per bar
+    const kicks = [0, 6, 10, 16, 22, 26, 32, 38, 42, 48, 54, 58]
+    for (let seed = 0; seed < 12; seed++) {
+      clearMotifs(); clearCompCounters()
+      const plan = buildFreeplayCompPlan(ctx({ bars: 2, energy: 0.9, kickTimes16ths: kicks, rng: mulberry32(seed) }))
+      expect(plan.length).toBeGreaterThanOrEqual(1)   // never comps itself into silence
+      for (const ev of plan) {
+        const slot = slotOf(ev.time)
+        if (slot === 0) continue  // downbeat chord+kick together is the head-nod, allowed
+        expect([6, 10], `comp doubled kick slot ${slot} (seed ${seed})`).not.toContain(slot)
+      }
+    }
+  })
+
+  it('never returns an empty plan even when kicks cover the whole motif', () => {
+    const everySlot = Array.from({ length: 16 }, (_, i) => i)
+    const plan = buildFreeplayCompPlan(ctx({ bars: 2, energy: 0.9, kickTimes16ths: everySlot }))
+    expect(plan.length).toBeGreaterThanOrEqual(1)
+    expect(slotOf(plan[0].time)).toBe(0)
+  })
+
   it('low-energy 2-bar plan pads both bars (softer re-attack, no dead second bar)', () => {
     const plan = buildFreeplayCompPlan(ctx({ bars: 2, energy: 0.2 }))
     expect(plan).toHaveLength(2)

--- a/client/src/organism/generators/freeplay/utils.ts
+++ b/client/src/organism/generators/freeplay/utils.ts
@@ -27,6 +27,11 @@ export function setFreeplaySeed(seed: number | null): number {
   return sessionSalt
 }
 
+/** Whether a seed is currently pinned (same beat on every start). */
+export function isSeedPinned(): boolean {
+  return pinnedSeed !== null
+}
+
 /** Called once per organism start: fresh salt, unless a seed is pinned. */
 export function rerollSessionSalt(): number {
   if (pinnedSeed === null) sessionSalt = randomSalt()

--- a/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
+++ b/docs/superpowers/specs/2026-07-02-freeplay-generators-design.md
@@ -326,3 +326,37 @@ By-ear verdict on §9 in production: "almost but not there" — mix/loudness fee
 Still open if the melodic side needs more: chord instrument choice per
 sub-genre (GM soundfont defaults read dated), melody/chord call-and-response,
 arrangement moments (§9 deferred list).
+
+---
+
+## 11. Band awareness — "make sure they all are aware of each other" (2026-07-03)
+
+User's direction after §10. Awareness map at that point:
+
+| Channel | Existed? |
+|---|---|
+| One swing source for all players | ✅ (June) |
+| One voicing source (Conductor) for bass/chords/melody | ✅ (June) |
+| Bass hears the kick (`setKickAnchors`, ≥60% onsets locked) | ✅ (§4.3) |
+| Chords avoid the SNARE backbeat | ✅ (§4.5) |
+| Chords hear the KICK | ❌ — `kickTimes16ths: []`, chords were deaf |
+| Chord cycle phase-locked to the band's bars | ❌ — part started unaligned |
+
+Fixed:
+1. Orchestrator pushes the same kick anchors to `chord.setKickAnchors()` it
+   already pushes to bass (both `buildDrumHits` and the mutate path).
+2. `buildFreeplayCompPlan` drops any comp slot that lands ON a kick (downbeat
+   exempt — chord+kick on beat 1 is the head-nod). The dev-bar push dodges
+   kicks via neighbours. Empty-plan guard: at minimum the downbeat anchor
+   survives, so harmony never vanishes on kick-heavy patterns.
+3. Chord part starts with `livePartStartOffset(startAt, loopBars)` — the
+   statement/development cycle stays phase-locked to the band's bar count like
+   drums (4) and bass (4) already were.
+
+Plus the §10 seed contract got its UI: 🎲 Beat Seed panel in the Command
+Center (current seed display, PINNED/RANDOM toggle, seed input).
+
+Deeper awareness still on the table (own design pass): melody↔chords
+call-and-response, fill-aware comping (all followers thin out under the bar-4
+drum fill), shared micro-timing pocket (bass/chords riding the drums' groove
+template offsets).


### PR DESCRIPTION
Two commits, spec §10–11:

**🎲 Beat Seed panel** (Command Center, under Drums): shows the seed behind the currently playing beat, a PINNED/RANDOM toggle (pin = replay this exact beat on every start; unpin = new beat each start), and a numeric input to SET a saved seed. No more console needed.

**Band awareness** — audit found the bass already locks to the kick, but the chords were deaf (`kickTimes16ths: []`) and the comp cycle drifted phase per rebuild:
- Orchestrator pushes the drum pattern's kick anchors to `ChordGenerator` through the same channel the bass uses.
- The comp plan now sits in the pockets **between** kicks: slots landing on a kick are dropped (downbeat exempt — chord+kick together on beat 1 is the head-nod), the development-bar push dodges kicks via neighbour slots, and an empty-plan guard keeps the downbeat so harmony never vanishes on kick-heavy patterns.
- Chord part starts phase-locked (`livePartStartOffset`) so the 2-bar statement/development cycle stays aligned with the band's bar count like drums and bass.

595 unit tests green (2 new kick-awareness contracts), `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_