### PR TITLE
feat(organism): instrumental Duet — chords answer the melody's rests in listening mode

### DIFF
--- a/client/src/organism/conductor/__tests__/duet.test.ts
+++ b/client/src/organism/conductor/__tests__/duet.test.ts
@@ -52,3 +52,46 @@ describe('planAnswer', () => {
     expect(hot!.velocity).toBeLessThanOrEqual(0.95)
   })
 })
+
+// ── Instrumental Duet — the band answers itself in listening mode ───────────
+import { planInstrumentalAnswer, melodyIsQuiet } from '../duet'
+
+const instCtx = (over: Partial<import('../duet').InstrumentalDuetContext> = {}) => ({
+  melodyRestSec: 1.2,        // well past a beat at 90bpm (0.667s/beat)
+  beatSec: 60 / 90,
+  wasQuiet: false,           // rising edge
+  msSinceLastAnswer: 5000,   // not throttled
+  voiceActive: false,        // pure listening mode
+  ...over,
+})
+
+describe('planInstrumentalAnswer', () => {
+  it('answers a melody rest with a chord stab in listening mode', () => {
+    const cue = planInstrumentalAnswer(instCtx())
+    expect(cue).not.toBeNull()
+    expect(cue!.answer).toBe('stab')
+  })
+
+  it('fires on the rising edge of the rest only — not every silent frame', () => {
+    expect(planInstrumentalAnswer(instCtx({ wasQuiet: true }))).toBeNull()
+  })
+
+  it('does not treat the space between two 8th notes as a rest', () => {
+    // 0.3s gap at 90bpm is under the beat-and-a-quarter threshold
+    expect(planInstrumentalAnswer(instCtx({ melodyRestSec: 0.3 }))).toBeNull()
+  })
+
+  it('throttles back-to-back answers', () => {
+    expect(planInstrumentalAnswer(instCtx({ msSinceLastAnswer: 800 }))).toBeNull()
+  })
+
+  it('yields the floor to the vocal Duet while an MC is active', () => {
+    expect(planInstrumentalAnswer(instCtx({ voiceActive: true }))).toBeNull()
+  })
+
+  it('melodyIsQuiet threshold scales with tempo', () => {
+    // 1.0s rest: quiet at 140bpm (beat 0.43s), NOT quiet at 60bpm (beat 1.0s)
+    expect(melodyIsQuiet(1.0, 60 / 140)).toBe(true)
+    expect(melodyIsQuiet(1.0, 60 / 60)).toBe(false)
+  })
+})

--- a/client/src/organism/conductor/duet.ts
+++ b/client/src/organism/conductor/duet.ts
@@ -51,3 +51,48 @@ export function planAnswer(performer: PerformerState, ctx: DuetContext): DuetCue
   const velocity = Math.max(0.3, Math.min(0.95, 0.4 + energy * 0.5))
   return { answer, velocity }
 }
+
+// ── Instrumental Duet — the band answers ITSELF ─────────────────────────────
+//
+// The vocal Duet above only fires on an MC's breath gaps: in pure listening
+// mode nothing converses. Here the MELODY plays the MC's role — its committed
+// rests between motifs ARE the call gaps — and the chords answer with a stab
+// in the pocket the melody left. Same DuetCue, same executeDuetCue path in the
+// orchestrator (quantized to the next 8th); this is a third CUE SOURCE into
+// the existing engine, not a rival system.
+
+export interface InstrumentalDuetContext {
+  /** Seconds since the melody's last note ended (transport running). */
+  melodyRestSec: number
+  /** Seconds per beat at the current tempo. */
+  beatSec: number
+  /** Quiet-state from the PREVIOUS frame — answers fire on the rising edge of
+   *  the rest, the moment the melody's phrase lands, not on every silent frame. */
+  wasQuiet: boolean
+  /** ms since the last instrumental answer — throttle. */
+  msSinceLastAnswer: number
+  /** An MC is actively performing — the vocal Duet owns the conversation. */
+  voiceActive: boolean
+  /** Minimum spacing between answers (ms). Default 2500. */
+  minGapMs?: number
+}
+
+/** The melody counts as resting after a beat-and-a-quarter of silence — long
+ *  enough to be a deliberate phrase-end, not the space between two 8th notes. */
+export function melodyIsQuiet(restSec: number, beatSec: number): boolean {
+  return restSec > beatSec * 1.25
+}
+
+/**
+ * Decide the chords' answer to a melody rest, or null if now is not the moment.
+ * Pure: same inputs → same cue. The orchestrator owns edge/throttle state.
+ */
+export function planInstrumentalAnswer(ctx: InstrumentalDuetContext): DuetCue | null {
+  if (ctx.voiceActive) return null
+  const quiet = melodyIsQuiet(ctx.melodyRestSec, ctx.beatSec)
+  if (!quiet || ctx.wasQuiet) return null   // rising edge only
+  if (ctx.msSinceLastAnswer < (ctx.minGapMs ?? 2500)) return null
+  // The melody is the one resting — answering with a lead lick would fill its
+  // own silence. The chords punctuate instead: a soft comp stab in the pocket.
+  return { answer: 'stab', velocity: 0.55 }
+}

--- a/client/src/organism/generators/GeneratorOrchestrator.ts
+++ b/client/src/organism/generators/GeneratorOrchestrator.ts
@@ -22,7 +22,7 @@ import { orgLog } from '../../lib/perf/organismLog'
 import type { InstrumentPerformerId } from '../performers'
 import { reseedPerformerSelection } from '../performers'
 import { getConductor } from '../conductor/Conductor'
-import { planAnswer, type DuetCue } from '../conductor/duet'
+import { planAnswer, planInstrumentalAnswer, melodyIsQuiet, type DuetCue } from '../conductor/duet'
 import type { PerformerState } from '../audio/types'
 import { loadRealInstruments } from '../instruments/realInstruments'
 import type { ArrangementPlan } from '@shared/arrangement'
@@ -98,6 +98,12 @@ export class GeneratorOrchestrator {
   private duetEnabled: boolean = true
   private duetWasBreathing: boolean = false
   private duetLastAnswerMs: number = 0
+
+  // Instrumental Duet — the band answers ITSELF in listening mode: the chords
+  // stab into the melody's rests (see conductor/duet.ts planInstrumentalAnswer).
+  // Same executeDuetCue path as the vocal Duet; this is only the cue state.
+  private instDuetWasQuiet: boolean = false
+  private instDuetLastAnswerMs: number = 0
 
   // ── Freeplay (spec 2026-07-02) ──
   private drumFreeplay = true
@@ -503,6 +509,8 @@ export class GeneratorOrchestrator {
     // Reset Duet edge/throttle so a new session doesn't fire a stale answer.
     this.duetWasBreathing = false
     this.duetLastAnswerMs = 0
+    this.instDuetWasQuiet = false
+    this.instDuetLastAnswerMs = 0
     // Silence all generators immediately — continuous sources like the pink
     // noise in TextureGenerator keep producing audio after Transport stops.
     // Silence all generators immediately — continuous sources like the pink
@@ -782,6 +790,45 @@ export class GeneratorOrchestrator {
     this.duetWasBreathing = performer.breathingNow
     if (!cue) return
     this.duetLastAnswerMs = now
+    this.executeDuetCue(cue)
+  }
+
+  /**
+   * Instrumental Duet decision. Runs every frame from processFrame: watches
+   * how long the melody has been resting (its own phrase-end signal) and, on
+   * the rising edge of a real rest, cues a chord stab through the SAME
+   * executeDuetCue path as the vocal Duet. Gated off while an MC is active —
+   * the vocal Duet owns the conversation then.
+   */
+  private maybeAnswerMelodyRest(voiceActive: boolean): void {
+    if (!this.duetEnabled || !this.melodyEnabled || !this.chordEnabled) {
+      this.instDuetWasQuiet = false
+      return
+    }
+    const transport = Tone.getTransport()
+    if (transport.state !== 'started') {
+      this.instDuetWasQuiet = false
+      return
+    }
+    const lastNoteEnd = this.melody.getLastNoteEndSec()
+    if (lastNoteEnd <= 0) {
+      // Melody hasn't played yet this run — nothing to answer.
+      this.instDuetWasQuiet = false
+      return
+    }
+
+    const beatSec = 60 / (transport.bpm.value || 90)
+    const restSec = Tone.now() - lastNoteEnd
+    const cue = planInstrumentalAnswer({
+      melodyRestSec: restSec,
+      beatSec,
+      wasQuiet: this.instDuetWasQuiet,
+      msSinceLastAnswer: performance.now() - this.instDuetLastAnswerMs,
+      voiceActive,
+    })
+    this.instDuetWasQuiet = melodyIsQuiet(restSec, beatSec)
+    if (!cue) return
+    this.instDuetLastAnswerMs = performance.now()
     this.executeDuetCue(cue)
   }
 
@@ -1288,6 +1335,10 @@ export class GeneratorOrchestrator {
     if (this.melodyEnabled) this.melody.processFrame(physics, organism)
     this.texture.processFrame(physics, organism)
     if (this.chordEnabled)  this.chord.processFrame(physics, organism)
+
+    // Instrumental Duet: in listening mode (no MC on the mic) the chords
+    // answer the melody's phrase-end rests with a comp stab.
+    this.maybeAnswerMelodyRest(physics.voiceActive)
 
     // Density feedback loop: report generator activity levels to PhysicsEngine
     if (this.physicsEngineRef) {

--- a/client/src/organism/generators/MelodyGenerator.ts
+++ b/client/src/organism/generators/MelodyGenerator.ts
@@ -791,8 +791,16 @@ export class MelodyGenerator extends GeneratorBase {
     this.hasStartedPlayback = false
     this.lastRebuildTime = -Infinity
     this.sectionBehavior = null
+    this.lastNoteEndSec  = 0
     this.setOutputLevel(0)
   }
+
+  // ── Instrumental Duet signal ─────────────────────────────────────────
+  // Audio-clock time (seconds) when the melody's most recent note ends.
+  // 0 = the melody hasn't played yet this run (orchestrator ignores it).
+  private lastNoteEndSec = 0
+
+  getLastNoteEndSec(): number { return this.lastNoteEndSec }
 
   applyPitchOffset(semitones: number): void {
     this.pitchOffsetSemitones = Math.round(semitones)
@@ -942,6 +950,13 @@ export class MelodyGenerator extends GeneratorBase {
     this.emitNoteEvents(events)
 
     this.part = new Tone.Part((time, event) => {
+      // Instrumental Duet signal: when this note ENDS, the melody may be
+      // resting — the orchestrator watches this to cue chord answers into the
+      // rests between motifs (see conductor/duet.ts planInstrumentalAnswer).
+      try {
+        this.lastNoteEndSec = Math.max(this.lastNoteEndSec, time + Tone.Time(event.dur).toSeconds())
+      } catch { /* malformed duration — skip the signal, never the note */ }
+
       const presenceDuck = Math.max(0.3, 1 - this.currentPresence * 0.5)
       const voice = this.isSamplerReady() ? this.synth : this.fallbackSynth
       const finalVel = event.vel * presenceDuck

--- a/docs/superpowers/specs/2026-06-18-conductor-directs-the-band.md
+++ b/docs/superpowers/specs/2026-06-18-conductor-directs-the-band.md
@@ -224,6 +224,14 @@ Conductor API already in place to build on: `currentChord()`/`nextChord()`
       HARMONIC/MELODIC REPLY — the band's own idea, played AFTER the phrase, in the gap.
       Different layer, different moment; they don't collide. Drum fills as a Duet answer are
       intentionally deferred so the Duet never competes with WOW for the drum layer.
+- [x] **D3 — Instrumental Duet.** ✅ 2026-07-03. The vocal Duet only fires on MC breath
+      gaps — pure listening mode had no conversation. Third cue source into the SAME
+      engine: the MELODY plays the MC's role. `planInstrumentalAnswer` (pure, duet.ts)
+      fires on the rising edge of a melody rest (> 1.25 beats since the melody's last
+      note ended — `MelodyGenerator.getLastNoteEndSec()`, updated per Part callback) and
+      cues a chord stab through the existing `executeDuetCue` (next-8th quantized).
+      Throttled 2.5s; gated off while `voiceActive` (the vocal Duet keeps the floor);
+      edge/throttle state reset on stop. TDD'd (6 cases in duet.test.ts).
 
 ### Still captured for later (after the duet is heard)
 - The deeper source of "taste" (orchestration/voicing it wasn't explicitly told) is


### PR DESCRIPTION
The vocal Duet (D1/D2, 2026-06-20) only fires on an MC's breath gaps — in pure listening mode the band never conversed. This adds **D3: a third cue source into the same Duet engine**, no rival system:

- `planInstrumentalAnswer` + `melodyIsQuiet` (pure, `conductor/duet.ts`): on the rising edge of a melody rest (> 1.25 beats of silence, tempo-scaled) cue a soft chord stab. Throttled 2.5 s; yields to the vocal Duet while an MC is active.
- `MelodyGenerator` tracks `lastNoteEndSec` per Part callback (its phrase-end signal), reset with the generator.
- Orchestrator runs the decision per frame beside the vocal Duet's edge/throttle state and fires through the existing `executeDuetCue` (next-8th quantized); state reset on stop.

601 unit tests green (6 new duet contracts), `tsc` clean. Conductor spec D3 documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_