### PR TITLE
fix(organism): presets explicitly pick their instruments — Violin Trap gets a violin, sad presets play sad

### DIFF
--- a/client/src/features/organism/OrganismProvider.tsx
+++ b/client/src/features/organism/OrganismProvider.tsx
@@ -146,6 +146,25 @@ async function pickInstrumentNotes(family: string): Promise<Record<string, strin
   return pick.notes
 }
 
+/**
+ * Apply a preset's explicit band members + mood. A preset NAMED after an
+ * instrument ("Violin Trap" 🎻) must audibly produce that instrument — before
+ * this, presets only set mode/sub-genre and the performer router re-rolled the
+ * lead every start, so the violin appeared maybe half the time. Roles the
+ * preset doesn't pin are CLEARED (null → router keeps its per-start variety)
+ * so a previous preset's explicit pick can't stick across preset changes.
+ * Runs on both cold quickStart and hot swapPreset, BEFORE orchestr.start().
+ */
+function applyPresetBand(
+  orchestr: NonNullable<React.MutableRefObject<GeneratorOrchestrator | null>['current']>,
+  preset: QuickStartPreset,
+): void {
+  orchestr.setInstrumentPerformer('lead',  preset.performers?.lead  ?? null)
+  orchestr.setInstrumentPerformer('chord', preset.performers?.chord ?? null)
+  orchestr.setInstrumentPerformer('bass',  preset.performers?.bass  ?? null)
+  orchestr.setMelodyEmotionalIntent(preset.emotionalIntent ?? null)
+}
+
 export function OrganismProvider({ children, userId, isGuest = false }: Props) {
   // Load persisted user profile (weighted average of past sessions)
   const { profile, recompute: recomputeProfile } = useProfile(userId, null)
@@ -1513,6 +1532,7 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
       if (preset.subGenre) {
         orchestr.swapSubGenre(preset.subGenre, preset.bpm)
       }
+      applyPresetBand(orchestr, preset)
       await waitForStartupParts()
 
       // Start v1 generators — real hip-hop drum samples + patterns from DrumPatternLibrary
@@ -1687,6 +1707,7 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
       if (preset.subGenre) {
         orchestr.swapSubGenre(preset.subGenre, preset.bpm)
       }
+      applyPresetBand(orchestr, preset)
       await waitForStartupParts()
       if (swapPresetTokenRef.current !== swapToken) return
       await orchestr.start(preset.bpm, true)

--- a/client/src/features/organism/QuickStartPresets.ts
+++ b/client/src/features/organism/QuickStartPresets.ts
@@ -16,6 +16,7 @@
 import { OrganismMode } from '../../organism/physics/types'
 import type { PhysicsState } from '../../organism/physics/types'
 import type { HipHopSubGenre } from '../../organism/state/MusicalState'
+import type { InstrumentPerformerId } from '../../organism/performers'
 
 export interface QuickStartPreset {
   id:          string
@@ -30,6 +31,20 @@ export interface QuickStartPreset {
   icon:        string
   physics:     PhysicsState
   loopPackId?: string    // ID of the LoopPack to load when Loops Mode is ON
+  /** Explicit band members. A preset NAMED after an instrument must audibly
+   *  produce that instrument — before this field, "Violin Trap" only set
+   *  mode=Glow, where violin was one of four router candidates re-rolled every
+   *  start (heard maybe half the time). Roles left undefined keep the router's
+   *  per-start variety AND are cleared on preset start so a previous preset's
+   *  pick can't stick. */
+  performers?: {
+    lead?:  InstrumentPerformerId
+    chord?: InstrumentPerformerId
+    bass?:  InstrumentPerformerId
+  }
+  /** Melody mood shaping (MelodyGenerator.setEmotionalIntent) — 'sad' narrows
+   *  dynamics into the soft range; cleared when the preset doesn't set it. */
+  emotionalIntent?: 'sad' | 'beautiful'
 }
 
 function makePhysics(overrides: Partial<PhysicsState> & { mode: OrganismMode; pulse: number }): PhysicsState {
@@ -57,6 +72,8 @@ export const QUICK_START_PRESETS: QuickStartPreset[] = [
     loopPackId: 'cymatics-vintage-80',
     label:    'Lucid',
     genre:    'Reference / Melodic Emo Trap',
+    performers: { lead: 'guitar-nylon' },
+    emotionalIntent: 'sad',
     bpm:      80,
     mode:     OrganismMode.Glow,
     subGenre: 'chill',
@@ -105,6 +122,8 @@ export const QUICK_START_PRESETS: QuickStartPreset[] = [
     allowedTemplateIds: ['storytelling', 'slow-burn', 'classic', 'bridge-heavy'],
     energy:   'medium',
     icon:     '🎻',
+    performers: { lead: 'violin', chord: 'strings' },
+    emotionalIntent: 'sad',
     physics: makePhysics({
       mode:     OrganismMode.Glow,
       pulse:    130,
@@ -289,6 +308,7 @@ export const QUICK_START_PRESETS: QuickStartPreset[] = [
     loopPackId: 'cymatics-vintage-76',
     label:  'Chill',
     genre:  'Chill / Melodic',
+    performers: { lead: 'flute' },
     bpm:    75,
     mode:   OrganismMode.Glow,
     subGenre: 'chill',
@@ -310,6 +330,7 @@ export const QUICK_START_PRESETS: QuickStartPreset[] = [
     id:     'funk-100',
     label:  'Funk',
     genre:  'Funk / Groove',
+    performers: { lead: 'guitar-clean' },
     bpm:    100,
     mode:   OrganismMode.Smoke,
     subGenre: 'west-coast',
@@ -368,6 +389,7 @@ export const QUICK_START_PRESETS: QuickStartPreset[] = [
     loopPackId: 'cymatics-vintage-81',
     label:  'Story',
     genre:  'Storytelling / Narrative',
+    performers: { lead: 'piano' },
     bpm:    80,
     mode:   OrganismMode.Smoke,
     subGenre: 'chill',

--- a/client/src/features/organism/__tests__/QuickStartPresets.test.ts
+++ b/client/src/features/organism/__tests__/QuickStartPresets.test.ts
@@ -61,3 +61,22 @@ describe('QuickStartPresets — Real Beat presets', () => {
     }
   })
 })
+
+// ── Explicit band members — a preset named after an instrument must ask for it ──
+import { INSTRUMENT_PERFORMERS_BY_ID } from '../../../organism/performers/InstrumentRegistry'
+
+describe('preset performers', () => {
+  it('every explicit performer id exists in the registry (typos fall back to piano silently)', () => {
+    for (const preset of QUICK_START_PRESETS) {
+      for (const [role, id] of Object.entries(preset.performers ?? {})) {
+        expect(INSTRUMENT_PERFORMERS_BY_ID.has(id), `${preset.id} ${role}: '${id}' not in registry`).toBe(true)
+      }
+    }
+  })
+
+  it('Violin Trap explicitly asks for a violin lead (the "no violin in Violin Trap" bug)', () => {
+    const preset = getQuickStartPreset('ref-violin-trap-130')
+    expect(preset?.performers?.lead).toBe('violin')
+    expect(preset?.emotionalIntent).toBe('sad')
+  })
+})


### PR DESCRIPTION
Root cause of "sad violin preset has no violin / same with flute, guitar, piano": every one of those instruments **is** registered with a self-hosted soundfont and playing techniques — but presets had no instrument field. "Violin Trap" only set `mode: Glow`, where violin was one of four router candidates re-rolled on every start by the per-start performer reseed. Nothing was broken in the instruments; nothing ever *asked* for them.

- `QuickStartPreset` gains `performers { lead/chord/bass }` + `emotionalIntent`, applied through the router's existing `explicitId` channel (which always won over scoring, but had no preset caller).
- `applyPresetBand()` runs on both cold `quickStart` and hot `swapPreset`, before start. Roles a preset doesn't pin are **cleared**, so a previous preset's pick can't stick; unpinned roles keep the per-start variety.
- Preset assignments: **Violin Trap** → violin lead + string chords + `sad` intent (natural minor, contained dynamics) · **Lucid** → nylon guitar + sad · **Chill** → flute lead · **Story** → piano lead · **Funk** → clean electric guitar lead.
- Guard test: every explicit performer id must exist in the registry (a typo would silently fall back to piano).

603 unit tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_