### PR TITLE
fix(organism): user instrument picks outrank presets; violin joins the boom-bap pool

### DIFF
--- a/client/src/features/organism/OrganismProvider.tsx
+++ b/client/src/features/organism/OrganismProvider.tsx
@@ -150,18 +150,23 @@ async function pickInstrumentNotes(family: string): Promise<Record<string, strin
  * Apply a preset's explicit band members + mood. A preset NAMED after an
  * instrument ("Violin Trap" 🎻) must audibly produce that instrument — before
  * this, presets only set mode/sub-genre and the performer router re-rolled the
- * lead every start, so the violin appeared maybe half the time. Roles the
- * preset doesn't pin are CLEARED (null → router keeps its per-start variety)
- * so a previous preset's explicit pick can't stick across preset changes.
+ * lead every start, so the violin appeared maybe half the time.
+ *
+ * Precedence per role: USER pick (dropdown / vibe text) > preset > router.
+ * The user's choice survives preset starts — violin can totally be in
+ * boom-bap if the user says so. Roles with neither a user pick nor a preset
+ * pin are CLEARED (null → router keeps its per-start variety) so a previous
+ * preset's default can't stick across preset changes.
  * Runs on both cold quickStart and hot swapPreset, BEFORE orchestr.start().
  */
 function applyPresetBand(
   orchestr: NonNullable<React.MutableRefObject<GeneratorOrchestrator | null>['current']>,
   preset: QuickStartPreset,
+  userPicks: OrganismInstrumentAssignments,
 ): void {
-  orchestr.setInstrumentPerformer('lead',  preset.performers?.lead  ?? null)
-  orchestr.setInstrumentPerformer('chord', preset.performers?.chord ?? null)
-  orchestr.setInstrumentPerformer('bass',  preset.performers?.bass  ?? null)
+  orchestr.setInstrumentPerformer('lead',  userPicks.lead  ?? preset.performers?.lead  ?? null)
+  orchestr.setInstrumentPerformer('chord', userPicks.chord ?? preset.performers?.chord ?? null)
+  orchestr.setInstrumentPerformer('bass',  userPicks.bass  ?? preset.performers?.bass  ?? null)
   orchestr.setMelodyEmotionalIntent(preset.emotionalIntent ?? null)
 }
 
@@ -397,6 +402,11 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
     bass: null,
     chord: null,
   })
+  // Ref mirror so preset start/swap closures read the LIVE user picks —
+  // a user-chosen instrument (dropdown or vibe text) outranks the preset's
+  // default band: violin can totally be in boom-bap if the user says so.
+  const instrumentAssignmentsRef = useRef(instrumentAssignments)
+  instrumentAssignmentsRef.current = instrumentAssignments
   const [vibeInterpretation, setVibeInterpretation] = useState<{ text: string; result: string; confidence: number } | null>(null)
 
   // ACE Hybrid Stems Mode state
@@ -1532,7 +1542,7 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
       if (preset.subGenre) {
         orchestr.swapSubGenre(preset.subGenre, preset.bpm)
       }
-      applyPresetBand(orchestr, preset)
+      applyPresetBand(orchestr, preset, instrumentAssignmentsRef.current)
       await waitForStartupParts()
 
       // Start v1 generators — real hip-hop drum samples + patterns from DrumPatternLibrary
@@ -1707,7 +1717,7 @@ export function OrganismProvider({ children, userId, isGuest = false }: Props) {
       if (preset.subGenre) {
         orchestr.swapSubGenre(preset.subGenre, preset.bpm)
       }
-      applyPresetBand(orchestr, preset)
+      applyPresetBand(orchestr, preset, instrumentAssignmentsRef.current)
       await waitForStartupParts()
       if (swapPresetTokenRef.current !== swapToken) return
       await orchestr.start(preset.bpm, true)

--- a/client/src/organism/performers/InstrumentPerformerRouter.ts
+++ b/client/src/organism/performers/InstrumentPerformerRouter.ts
@@ -32,9 +32,12 @@ const MODE_ROLE_DEFAULTS: Partial<Record<string, Partial<Record<PerformerRole, I
     chord: ['piano', 'strings', 'rhodes'],        // piano block chords or string pads
   },
   gravel: {
-    lead: ['piano', 'sax', 'trumpet'],            // boom-bap: keys, horns
+    // boom-bap: keys, horns — and violin/strings, the classic sampled-loop
+    // flavour (RZA/Nas-era string leads). Violin was absent from this pool
+    // entirely, making it unreachable in boom-bap except by explicit pick.
+    lead: ['piano', 'sax', 'trumpet', 'violin'],
     bass: ['bass-synth', 'bass-electric'],
-    chord: ['piano', 'rhodes', 'guitar-nylon'],   // nylon guitar kept as optional flavor
+    chord: ['piano', 'rhodes', 'guitar-nylon', 'strings'],
   },
   smoke: {
     lead: ['sax', 'clarinet', 'violin', 'guitar-nylon'],


### PR DESCRIPTION
"Violin can totally be in boom-bap" — correct on both counts, so two fixes:

- **Precedence per role is now: user pick (dropdown / vibe text) > preset > router.** `applyPresetBand` reads the live `instrumentAssignments` ref, so a hand-picked violin survives preset starts and hot swaps instead of being cleared by the preset's defaults (a regression risk introduced in #29).
- **The gravel (boom-bap) router pools never contained violin or strings at all** — the classic sampled string-loop flavour was unreachable except by explicit pick. Violin joins the lead pool and strings the chord pool, so the per-start reroll can land there organically.

603 unit tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_