### PR TITLE
feat(organism): wildcard instrument starts — any instrument can be in any genre

### DIFF
--- a/client/src/organism/performers/InstrumentPerformerRouter.ts
+++ b/client/src/organism/performers/InstrumentPerformerRouter.ts
@@ -72,6 +72,21 @@ function seededJitter(profileId: string): number {
   return (h / 9973) * 3   // 0..3 — reorders near-tied candidates, not the field
 }
 
+/** Seeded 0..1 roll keyed by a string — stable within a session like the jitter. */
+function seededRoll(key: string): number {
+  let h = performerSessionSeed
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) % 9973
+  return h / 9973
+}
+
+/** How often a start ignores the mode's preferred pool entirely and gives every
+ *  role-capable instrument a fair roll. ANY instrument can be in ANY genre —
+ *  the genre lives in HOW it's played (skeletons, swing, comping idiom,
+ *  articulations), not the timbre. Without this, the +12 preference bonus made
+ *  the pools de facto gates: a violin boom-bap or marimba trap could never
+ *  happen organically. */
+const WILDCARD_CHANCE = 0.18
+
 export function selectInstrumentPerformer(ctx: PerformerSelectionContext): InstrumentPerformerProfile {
   if (ctx.explicitId) {
     const explicit = INSTRUMENT_PERFORMERS_BY_ID.get(ctx.explicitId)
@@ -79,14 +94,23 @@ export function selectInstrumentPerformer(ctx: PerformerSelectionContext): Instr
   }
 
   const candidates = INSTRUMENT_PERFORMERS.filter(profile => profile.roles.includes(ctx.role))
-  const preferred = MODE_ROLE_DEFAULTS[ctx.mode]?.[ctx.role] ?? [DEFAULT_BY_ROLE[ctx.role]]
+  const modePool = MODE_ROLE_DEFAULTS[ctx.mode]?.[ctx.role]
+  const preferred = modePool ?? [DEFAULT_BY_ROLE[ctx.role]]
+  // Wildcard start: the preferred pool becomes advisory, not a gate — the mild
+  // energy/brightness/mode-bias scoring below still keeps the pick sensible.
+  // Scope: lead/chord only (instrument COLOR lives there; the low-end is
+  // structural genre identity), and only when the mode actually has a pool —
+  // an unknown mode keeps its stable piano default.
+  const wildcard = modePool !== undefined
+    && (ctx.role === 'lead' || ctx.role === 'chord')
+    && seededRoll(`wildcard:${ctx.role}:${ctx.mode}`) < WILDCARD_CHANCE
   let best = candidates[0] ?? INSTRUMENT_PERFORMERS_BY_ID.get(DEFAULT_BY_ROLE[ctx.role])!
   let bestScore = -Infinity
 
   for (const profile of candidates) {
     let score = 0
     const preferredIdx = preferred.indexOf(profile.id)
-    if (preferredIdx >= 0) score += 12 - preferredIdx
+    if (!wildcard && preferredIdx >= 0) score += 12 - preferredIdx
     if (profile.modeBias.includes(ctx.mode)) score += 4
     if (ctx.energy > 0.7 && profile.tags.includes('aggressive')) score += 3
     if (ctx.energy < 0.35 && (profile.tags.includes('warm') || profile.tags.includes('air'))) score += 2

--- a/client/src/organism/performers/__tests__/InstrumentPerformerRouter.test.ts
+++ b/client/src/organism/performers/__tests__/InstrumentPerformerRouter.test.ts
@@ -9,17 +9,26 @@ import {
 import { INSTRUMENT_PERFORMERS_BY_ID } from '../InstrumentRegistry'
 
 describe('InstrumentPerformerRouter', () => {
-  // Selection carries a per-start variety seed (reseedPerformerSelection) so
-  // cold starts don't all pick the same instrument — the contract is that the
-  // winner stays WITHIN the mode's idiomatic preferred list (the jitter is too
-  // small to lift a non-preferred candidate over the preference gap).
-  it('selects idiomatic lead instruments by mode', () => {
-    expect(['harp', 'violin', 'sitar', 'flute'])
-      .toContain(selectInstrumentPerformer({ role: 'lead', mode: 'ice', energy: 0.4 }).id)
-    expect(['violin', 'guitar-nylon', 'clarinet', 'flute'])
-      .toContain(selectInstrumentPerformer({ role: 'lead', mode: 'glow', energy: 0.5 }).id)
-    expect(['piano', 'trumpet', 'rhodes'])
-      .toContain(selectInstrumentPerformer({ role: 'lead', mode: 'heat', energy: 0.9 }).id)
+  // Selection carries a per-start variety seed (reseedPerformerSelection).
+  // Contract (2026-07-03, "any instrument can be in any genre"): the winner is
+  // USUALLY from the mode's idiomatic pool, but a wildcard start may pick any
+  // role-capable instrument — the genre lives in HOW it's played, not the
+  // timbre. So the assertion is statistical, not absolute.
+  it('lead picks are mostly idiomatic for the mode across reseeds', () => {
+    const pools: Array<[string, string[]]> = [
+      ['ice',  ['harp', 'violin', 'sitar', 'flute']],
+      ['glow', ['violin', 'guitar-nylon', 'clarinet', 'flute']],
+      ['heat', ['piano', 'trumpet', 'rhodes']],
+    ]
+    for (const [mode, pool] of pools) {
+      let idiomatic = 0
+      const RUNS = 40
+      for (let i = 0; i < RUNS; i++) {
+        reseedPerformerSelection()
+        if (pool.includes(selectInstrumentPerformer({ role: 'lead', mode, energy: 0.5 }).id)) idiomatic++
+      }
+      expect(idiomatic, `${mode}: only ${idiomatic}/${RUNS} idiomatic`).toBeGreaterThan(RUNS * 0.55)
+    }
   })
 
   it('keeps flute as an optional color instead of the generic lead fallback', () => {
@@ -57,5 +66,34 @@ describe('InstrumentPerformerRouter', () => {
   it('keeps plucked chord voicings compact', () => {
     const guitar = INSTRUMENT_PERFORMERS_BY_ID.get('guitar-nylon')!
     expect(conformChordToInstrument(['C2', 'E2', 'G2', 'B2', 'D3'], guitar)).toHaveLength(4)
+  })
+})
+
+// ── Wildcard starts — any instrument can be in any genre ────────────────────
+// The genre lives in HOW the instrument is played (skeletons, swing, comping
+// idiom), not the timbre. The preferred pools are taste-defaults, not gates.
+import { reseedPerformerSelection, selectInstrumentPerformer as pick } from '../InstrumentPerformerRouter'
+
+describe('wildcard instrument selection', () => {
+  it('boom-bap lead occasionally lands OUTSIDE the preferred pool, but the house sound stays the norm', () => {
+    const preferredGravelLeads = new Set(['piano', 'sax', 'trumpet', 'violin'])
+    let outside = 0
+    const RUNS = 80
+    for (let i = 0; i < RUNS; i++) {
+      reseedPerformerSelection()
+      const lead = pick({ role: 'lead', mode: 'gravel', energy: 0.5 })
+      if (!preferredGravelLeads.has(lead.id)) outside++
+    }
+    // ~18% wildcard chance: P(zero in 80) ≈ 0.82^80 ≈ 1e-7 — must appear...
+    expect(outside, 'no wildcard pick in 80 reseeds').toBeGreaterThan(0)
+    // ...but the preferred pool must still dominate (taste-default, not chaos).
+    expect(outside, `wildcards took over: ${outside}/${RUNS}`).toBeLessThan(RUNS * 0.45)
+  })
+
+  it('an explicit pick is never overridden by the wildcard roll', () => {
+    for (let i = 0; i < 20; i++) {
+      reseedPerformerSelection()
+      expect(pick({ role: 'lead', mode: 'gravel', energy: 0.5, explicitId: 'violin' }).id).toBe('violin')
+    }
   })
 })


### PR DESCRIPTION
Implements the owner's principle: *"any instrument can be in any type of music — the way the music and instrument is played is what makes it that genre."*

The architecture already agrees — genre identity lives in the immutable skeletons, swing, comping idiom, and articulations — but the performer router's +12 preference bonus made the mode pools de facto **gates** on timbre: a marimba trap lead or sitar boom-bap could never happen even though the playing style would keep it firmly in genre.

- **18% of starts are wildcards**: the mode pool becomes advisory and every role-capable instrument gets a fair roll (mild energy/brightness/mode-bias scoring still keeps picks sensible).
- **Scope: lead + chord only** — instrument *color* lives there; the low-end stays structural. Unknown modes keep their stable defaults.
- **Explicit picks (user dropdown / vibe text / preset) still always win.**
- Contract test updated: lead picks are *mostly* idiomatic across reseeds (statistical) rather than always-in-pool (absolute).

605 unit tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwE2oFa2ztyTYDLVrDxjg)_