### PR TITLE
fix(transcription): compress audio over Whisper's 25 MiB cap

### DIFF
--- a/server/services/__tests__/transcriptionService.test.ts
+++ b/server/services/__tests__/transcriptionService.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { needsWhisperCompression } from '../transcriptionService'
+
+const MiB = 1024 * 1024
+
+describe('needsWhisperCompression', () => {
+  it('leaves small files alone (under the 24 MiB safety threshold)', () => {
+    expect(needsWhisperCompression(5 * MiB)).toBe(false)
+    expect(needsWhisperCompression(24 * MiB)).toBe(false)
+  })
+
+  it('compresses files that would trip Whisper 25 MiB cap', () => {
+    // The real failure: a ~26.4 MB WAV → OpenAI 413.
+    expect(needsWhisperCompression(26_380_250)).toBe(true)
+    expect(needsWhisperCompression(25 * MiB)).toBe(true)
+  })
+
+  it('uses a margin below the hard 25 MiB limit so borderline files are re-encoded', () => {
+    expect(needsWhisperCompression(24 * MiB + 1)).toBe(true)
+  })
+})

--- a/server/services/transcriptionService.ts
+++ b/server/services/transcriptionService.ts
@@ -1,6 +1,36 @@
 import fs from 'fs';
+import os from 'os';
+import crypto from 'crypto';
 import OpenAI from 'openai';
+import ffmpeg from 'fluent-ffmpeg';
 import path from 'path';
+
+// OpenAI Whisper rejects uploads over 25 MiB (26214400 bytes) with a 413.
+// Uncompressed WAV is ~10 MB/min, so even short songs exceed it. We compress
+// above a safety threshold — Whisper only uses 16 kHz mono internally, so a
+// 16 kHz mono MP3 loses no transcription accuracy while shrinking ~10x.
+const WHISPER_MAX_BYTES = 25 * 1024 * 1024;
+const WHISPER_SAFE_BYTES = 24 * 1024 * 1024;
+
+/** Whether a file of this size must be compressed before hitting Whisper. */
+export function needsWhisperCompression(sizeBytes: number): boolean {
+  return sizeBytes > WHISPER_SAFE_BYTES;
+}
+
+/** Transcode any audio to a compact 16 kHz mono MP3 in a temp file. Caller deletes it. */
+function compressForWhisper(filePath: string): Promise<string> {
+  const outPath = path.join(os.tmpdir(), `whisper-${crypto.randomBytes(6).toString('hex')}.mp3`);
+  return new Promise<string>((resolve, reject) => {
+    ffmpeg(filePath)
+      .audioChannels(1)
+      .audioFrequency(16000)
+      .audioBitrate('64k')
+      .format('mp3')
+      .on('end', () => resolve(outPath))
+      .on('error', (err) => reject(err))
+      .save(outPath);
+  });
+}
 
 // Initialize OpenAI client
 const openaiApiKey = process.env.OPENAI_API_KEY?.trim();
@@ -45,11 +75,29 @@ export async function transcribeAudio(filePath: string): Promise<TranscriptionRe
     throw new Error(`Audio file not found at path: ${filePath}`);
   }
 
+  let uploadPath = filePath;
+  let tempCompressed: string | null = null;
+
   try {
     console.log(`🎤 Starting transcription for file: ${path.basename(filePath)}`);
-    
+
+    // Whisper caps uploads at 25 MiB. Compress oversized audio (e.g. WAV) first.
+    const { size } = fs.statSync(filePath);
+    if (needsWhisperCompression(size)) {
+      console.log(`🗜️ Audio is ${(size / 1024 / 1024).toFixed(1)}MB (> Whisper limit) — compressing to 16kHz mono MP3`);
+      tempCompressed = await compressForWhisper(filePath);
+      uploadPath = tempCompressed;
+      const compressedSize = fs.statSync(uploadPath).size;
+      console.log(`✅ Compressed to ${(compressedSize / 1024 / 1024).toFixed(1)}MB`);
+      if (compressedSize > WHISPER_MAX_BYTES) {
+        throw new Error(
+          `Audio is too long to transcribe (still ${(compressedSize / 1024 / 1024).toFixed(1)}MB after compression). Try a shorter clip.`,
+        );
+      }
+    }
+
     const response = await openaiClient.audio.transcriptions.create({
-      file: fs.createReadStream(filePath),
+      file: fs.createReadStream(uploadPath),
       model: "whisper-1",
       response_format: "verbose_json",
       timestamp_granularities: ["word", "segment"] // Request both word and segment level timestamps
@@ -73,5 +121,13 @@ export async function transcribeAudio(filePath: string): Promise<TranscriptionRe
   } catch (error) {
     console.error("❌ Transcription failed:", error);
     throw new Error(`Transcription failed: ${(error as Error).message}`);
+  } finally {
+    if (tempCompressed) {
+      try {
+        fs.unlinkSync(tempCompressed);
+      } catch {
+        /* temp file cleanup is best-effort */
+      }
+    }
   }
 }


### PR DESCRIPTION
## Problem
Lyric video **sync** (`POST /api/speech-correction/transcribe`) returns a **500** on production for normal songs — user sees *"Server error — please try again shortly."*

## Root cause (from Railway prod logs)
```
❌ Transcription failed: APIError: 413 Maximum content size limit (26214400) exceeded (26380250 bytes read)
POST /api/speech-correction/transcribe 500
```
OpenAI Whisper rejects uploads over **25 MiB** (26214400 bytes). Uncompressed **WAV** is ~10 MB/min, so even a ~2.5-min song (~26.4 MB) trips it. Not a key/config or URL issue — the file is simply too big.

## Fix
Before calling Whisper, if the audio exceeds a 24 MiB safety threshold, transcode it to a **16 kHz mono MP3** via the existing `fluent-ffmpeg` dependency (Whisper downsamples to 16 kHz mono internally → **no accuracy loss**, ~10× smaller), send that, then delete the temp file in a `finally`. Audio still too large after compression fails with a clear "try a shorter clip" message instead of an opaque 500.

## Verification
- New unit test `needsWhisperCompression` — 3/3 pass
- `tsc --noEmit` — 0 errors
- Real prod confirmation requires deploy (Railway builds from `origin/main` on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)