### PR TITLE
feat(social): share lyric videos to the Social Hub + fix missing tables

### DIFF
--- a/client/src/components/studio/LyricVideoMaker.tsx
+++ b/client/src/components/studio/LyricVideoMaker.tsx
@@ -5,6 +5,7 @@ import {
   Pause,
   Play,
   RotateCcw,
+  Share2,
   SlidersHorizontal,
   Subtitles,
   Upload,
@@ -261,6 +262,7 @@ export default function LyricVideoMaker() {
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [isSharing, setIsSharing] = useState(false);
   const [duration, setDuration] = useState(0);
   const [offsetMs, setOffsetMs] = useState(0);
   const [snapToBeat, setSnapToBeat] = useState(true);
@@ -429,78 +431,91 @@ export default function LyricVideoMaker() {
     drawFrame(0);
   };
 
-  const exportVideo = async () => {
+  // Record the canvas + audio to a WebM blob. Browsers can only record WebM
+  // reliably; the server transcodes it to MP4. Shared by export and share.
+  const recordToWebm = async (): Promise<Blob> => {
     const canvas = canvasRef.current;
     const audio = audioRef.current;
-    if (!canvas || !audio || !uploadedAudio) return;
-
-    if (!lines.length) {
-      toast({
-        title: 'No lyrics to export',
-        description: 'Transcribe or paste lyrics first.',
-        variant: 'destructive',
-      });
-      return;
-    }
+    if (!canvas || !audio) throw new Error('Player not ready');
 
     const mimeType = getBestVideoMimeType();
-    if (!mimeType) {
-      toast({
-        title: 'Export unavailable',
-        description: 'This browser cannot record WebM video.',
-        variant: 'destructive',
-      });
-      return;
-    }
+    if (!mimeType) throw new Error('This browser cannot record video.');
 
-    setIsExporting(true);
     pausePreview();
     audio.currentTime = 0;
     drawFrame(0);
 
-    try {
-      const videoStream = canvas.captureStream(EXPORT_FPS);
-      const audioStream = getMediaElementCaptureStream(audio);
-      const stream = new MediaStream([
-        ...videoStream.getVideoTracks(),
-        ...(audioStream?.getAudioTracks() ?? []),
-      ]);
-      const recorder = new MediaRecorder(stream, { mimeType });
-      const chunks: Blob[] = [];
+    const videoStream = canvas.captureStream(EXPORT_FPS);
+    const audioStream = getMediaElementCaptureStream(audio);
+    const stream = new MediaStream([
+      ...videoStream.getVideoTracks(),
+      ...(audioStream?.getAudioTracks() ?? []),
+    ]);
+    const recorder = new MediaRecorder(stream, { mimeType });
+    const chunks: Blob[] = [];
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) chunks.push(event.data);
+    };
 
-      recorder.ondataavailable = (event) => {
-        if (event.data.size > 0) chunks.push(event.data);
+    const complete = new Promise<Blob>((resolve) => {
+      recorder.onstop = () => {
+        stream.getTracks().forEach((track) => track.stop());
+        resolve(new Blob(chunks, { type: mimeType }));
       };
+    });
 
-      const complete = new Promise<Blob>((resolve) => {
-        recorder.onstop = () => {
-          stream.getTracks().forEach((track) => track.stop());
-          resolve(new Blob(chunks, { type: mimeType }));
-        };
+    const loop = () => {
+      drawFrame(audio.currentTime);
+      if (recorder.state === 'recording' && !audio.ended) {
+        rafRef.current = requestAnimationFrame(loop);
+      }
+    };
+
+    recorder.start(250);
+    await audio.play();
+    loop();
+
+    const stopRecording = () => {
+      if (recorder.state === 'recording') recorder.stop();
+    };
+    audio.addEventListener('ended', stopRecording, { once: true });
+    window.setTimeout(stopRecording, Math.ceil((audio.duration || duration || 0) * 1000) + 750);
+
+    const blob = await complete;
+    audio.removeEventListener('ended', stopRecording);
+    return blob;
+  };
+
+  const resetPlayback = () => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.currentTime = 0;
+    }
+    setIsPreviewing(false);
+    stopDrawLoop();
+    drawFrame(0);
+  };
+
+  // Shared precheck: need audio + lyrics before recording anything.
+  const ensureReady = (): boolean => {
+    if (!uploadedAudio) return false;
+    if (!lines.length) {
+      toast({
+        title: 'No lyrics yet',
+        description: 'Transcribe or paste lyrics first.',
+        variant: 'destructive',
       });
+      return false;
+    }
+    return true;
+  };
 
-      const exportLoop = () => {
-        drawFrame(audio.currentTime);
-        if (recorder.state === 'recording' && !audio.ended) {
-          rafRef.current = requestAnimationFrame(exportLoop);
-        }
-      };
-
-      recorder.start(250);
-      await audio.play();
-      exportLoop();
-
-      const stopRecording = () => {
-        if (recorder.state === 'recording') recorder.stop();
-      };
-      audio.addEventListener('ended', stopRecording, { once: true });
-      window.setTimeout(stopRecording, Math.ceil((audio.duration || duration || 0) * 1000) + 750);
-
-      const webmBlob = await complete;
-      audio.removeEventListener('ended', stopRecording);
-
-      // Browsers can only record WebM; transcode server-side to a shareable MP4.
-      // No fallback: on failure the catch below surfaces a hard error toast.
+  const exportVideo = async () => {
+    if (!ensureReady()) return;
+    setIsExporting(true);
+    try {
+      const webmBlob = await recordToWebm();
       const form = new FormData();
       form.append('video', webmBlob, 'lyric-video.webm');
       const response = await fetch('/api/lyric-video/transcode', {
@@ -508,22 +523,17 @@ export default function LyricVideoMaker() {
         body: form,
         credentials: 'include',
       });
-      if (!response.ok) {
-        throw new Error(`MP4 export failed (${response.status})`);
-      }
+      if (!response.ok) throw new Error(`MP4 export failed (${response.status})`);
       const mp4Blob = await response.blob();
 
       const url = URL.createObjectURL(mp4Blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = `${sanitizeDownloadName(uploadedAudio.name)}-lyrics-video.mp4`;
+      link.download = `${sanitizeDownloadName(uploadedAudio?.name ?? 'lyric')}-lyrics-video.mp4`;
       link.click();
       window.setTimeout(() => URL.revokeObjectURL(url), 5000);
 
-      toast({
-        title: 'Video exported',
-        description: audioStream?.getAudioTracks().length ? 'MP4 ready to share.' : 'MP4 exported (no audio captured).',
-      });
+      toast({ title: 'Video exported', description: 'MP4 ready to share.' });
     } catch (error) {
       toast({
         title: 'Export failed',
@@ -531,12 +541,35 @@ export default function LyricVideoMaker() {
         variant: 'destructive',
       });
     } finally {
-      audio.pause();
-      audio.currentTime = 0;
-      setIsPreviewing(false);
       setIsExporting(false);
-      stopDrawLoop();
-      drawFrame(0);
+      resetPlayback();
+    }
+  };
+
+  const shareToFeed = async () => {
+    if (!ensureReady()) return;
+    setIsSharing(true);
+    try {
+      const webmBlob = await recordToWebm();
+      const form = new FormData();
+      form.append('video', webmBlob, 'lyric-video.webm');
+      form.append('caption', lyricsText.split('\n')[0]?.slice(0, 120) ?? '');
+      const response = await fetch('/api/lyric-video/share', {
+        method: 'POST',
+        body: form,
+        credentials: 'include',
+      });
+      if (!response.ok) throw new Error(`Share failed (${response.status})`);
+      toast({ title: 'Shared to feed', description: 'Your lyric video is live in the Social Hub.' });
+    } catch (error) {
+      toast({
+        title: 'Share failed',
+        description: error instanceof Error ? error.message : 'Could not share the video.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSharing(false);
+      resetPlayback();
     }
   };
 
@@ -625,10 +658,21 @@ export default function LyricVideoMaker() {
               size="sm"
               className="gap-2 bg-cyan-600 text-white hover:bg-cyan-500"
               onClick={exportVideo}
-              disabled={!canPreview || !lines.length || isExporting}
+              disabled={!canPreview || !lines.length || isExporting || isSharing}
             >
               <Download className="h-4 w-4" />
               {isExporting ? 'Exporting' : 'Export'}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              className="gap-2 bg-purple-600 text-white hover:bg-purple-500"
+              onClick={shareToFeed}
+              disabled={!canPreview || !lines.length || isExporting || isSharing}
+              title="Post this lyric video to the Social Hub feed"
+            >
+              <Share2 className="h-4 w-4" />
+              {isSharing ? 'Sharing' : 'Share to Feed'}
             </Button>
             <span className="ml-auto font-mono text-xs text-muted-foreground">
               {formatTime(audioRef.current?.currentTime || 0)} / {formatTime(duration)}

--- a/client/src/pages/social-hub.tsx
+++ b/client/src/pages/social-hub.tsx
@@ -65,6 +65,9 @@ function OrganismSessionCard({ post, isAuthenticated }: { post: any; isAuthentic
     caption = post.content || '';
   }
 
+  const isVideoPost =
+    post.type === 'lyric-video' || /\.(mp4|webm)(\?|$)/i.test(post.mediaUrl || '');
+
   const togglePlay = () => {
     if (!audioRef.current) return;
     if (isPlaying) {
@@ -108,27 +111,36 @@ function OrganismSessionCard({ post, isAuthenticated }: { post: any; isAuthentic
         )}
       </div>
 
-      {/* Audio player */}
+      {/* Media */}
       {post.mediaUrl ? (
-        <div className="flex items-center gap-3 mb-3 bg-black/30 rounded-lg p-2.5">
-          <button
-            onClick={togglePlay}
-            className="w-8 h-8 rounded-full bg-cyan-600 hover:bg-cyan-500 flex items-center justify-center text-white shrink-0 transition-colors"
-          >
-            {isPlaying ? '⏸' : '▶'}
-          </button>
-          <audio
-            ref={audioRef}
+        isVideoPost ? (
+          <video
             src={post.mediaUrl}
-            onEnded={() => setIsPlaying(false)}
-            className="flex-1 h-6"
             controls
-            style={{ height: 24, opacity: 0.7 }}
+            playsInline
+            className="w-full max-h-[420px] rounded-lg mb-3 bg-black"
           />
-        </div>
+        ) : (
+          <div className="flex items-center gap-3 mb-3 bg-black/30 rounded-lg p-2.5">
+            <button
+              onClick={togglePlay}
+              className="w-8 h-8 rounded-full bg-cyan-600 hover:bg-cyan-500 flex items-center justify-center text-white shrink-0 transition-colors"
+            >
+              {isPlaying ? '⏸' : '▶'}
+            </button>
+            <audio
+              ref={audioRef}
+              src={post.mediaUrl}
+              onEnded={() => setIsPlaying(false)}
+              className="flex-1 h-6"
+              controls
+              style={{ height: 24, opacity: 0.7 }}
+            />
+          </div>
+        )
       ) : (
         <div className="mb-3 bg-black/20 rounded-lg p-2.5 text-center text-xs text-cyan-500/40">
-          No audio recorded
+          No media
         </div>
       )}
 

--- a/server/migrations/20260703_add_social_hub_tables.sql
+++ b/server/migrations/20260703_add_social_hub_tables.sql
@@ -1,0 +1,125 @@
+-- Social Hub tables — additive & idempotent (CREATE TABLE IF NOT EXISTS).
+--
+-- Root cause (confirmed from prod Railway logs 2026-07-03):
+--   PostgresError: relation "social_posts" / "chat_messages" / "collab_invites"
+--   does not exist. These tables are defined in shared/schema.ts but were never
+--   pushed to the production database, so every Social Hub action 500s
+--   (posting, feed load, chat, collab).
+--
+-- Safe to run against production: IF NOT EXISTS skips tables that already exist,
+-- so only the missing ones are created. No ALTER/DROP — existing data untouched.
+-- Column types/defaults mirror shared/schema.ts exactly.
+
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id varchar REFERENCES users(id),
+  display_name varchar,
+  bio text,
+  avatar_url varchar,
+  website_url varchar,
+  social_links jsonb,
+  location varchar,
+  favorite_genres text[],
+  instruments text[],
+  skill_level varchar,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS project_shares (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id varchar REFERENCES projects(id),
+  shared_by_user_id varchar REFERENCES users(id),
+  shared_with_user_id varchar REFERENCES users(id),
+  permission varchar DEFAULT 'view',
+  created_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS project_collaborations (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id varchar REFERENCES projects(id),
+  user_id varchar REFERENCES users(id),
+  role varchar DEFAULT 'collaborator',
+  joined_at timestamp DEFAULT now(),
+  last_active_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS project_comments (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id varchar REFERENCES projects(id),
+  user_id varchar REFERENCES users(id),
+  content text NOT NULL,
+  parent_comment_id varchar,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS project_likes (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id varchar REFERENCES projects(id),
+  user_id varchar REFERENCES users(id),
+  created_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_follows (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  follower_id varchar REFERENCES users(id),
+  following_id varchar REFERENCES users(id),
+  created_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS social_posts (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id varchar REFERENCES users(id),
+  platform varchar NOT NULL,
+  content text NOT NULL,
+  type varchar NOT NULL,
+  title varchar,
+  url varchar,
+  media_url varchar,
+  project_id varchar REFERENCES projects(id),
+  likes integer DEFAULT 0,
+  comments integer DEFAULT 0,
+  shares integer DEFAULT 0,
+  views integer DEFAULT 0,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS social_connections (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id varchar REFERENCES users(id),
+  platform varchar NOT NULL,
+  platform_user_id varchar,
+  platform_username varchar,
+  access_token text,
+  refresh_token text,
+  connected boolean DEFAULT true,
+  followers integer DEFAULT 0,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS chat_messages (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  sender_id varchar REFERENCES users(id),
+  recipient_id varchar REFERENCES users(id),
+  conversation_id varchar NOT NULL,
+  content text NOT NULL,
+  message_type varchar DEFAULT 'text',
+  attachment_url varchar,
+  read_at timestamp,
+  created_at timestamp DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS collab_invites (
+  id serial PRIMARY KEY,
+  from_user_id text NOT NULL,
+  to_user_id text NOT NULL,
+  project_id integer,
+  type text NOT NULL,
+  message text,
+  status text NOT NULL DEFAULT 'pending',
+  created_at timestamp DEFAULT now(),
+  expires_at timestamp
+);

--- a/server/migrations/runMigrations.ts
+++ b/server/migrations/runMigrations.ts
@@ -339,6 +339,94 @@ export async function runMigrations() {
     await sql`CREATE INDEX IF NOT EXISTS idx_organism_profiles_computed_at ON organism_profiles(computed_at DESC)`;
     console.log('✅ Migration: organism_profiles table ensured');
 
+    // Social Hub tables — were defined in schema.ts but never pushed to prod,
+    // which 500'd every Social Hub action (posting/feed/chat/collab). Additive.
+    await sql`
+      CREATE TABLE IF NOT EXISTS user_profiles (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id varchar REFERENCES users(id),
+        display_name varchar, bio text, avatar_url varchar, website_url varchar,
+        social_links jsonb, location varchar,
+        favorite_genres text[], instruments text[], skill_level varchar,
+        created_at timestamp DEFAULT now(), updated_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS project_shares (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        project_id varchar REFERENCES projects(id),
+        shared_by_user_id varchar REFERENCES users(id),
+        shared_with_user_id varchar REFERENCES users(id),
+        permission varchar DEFAULT 'view', created_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS project_collaborations (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        project_id varchar REFERENCES projects(id),
+        user_id varchar REFERENCES users(id),
+        role varchar DEFAULT 'collaborator',
+        joined_at timestamp DEFAULT now(), last_active_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS project_comments (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        project_id varchar REFERENCES projects(id),
+        user_id varchar REFERENCES users(id),
+        content text NOT NULL, parent_comment_id varchar,
+        created_at timestamp DEFAULT now(), updated_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS project_likes (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        project_id varchar REFERENCES projects(id),
+        user_id varchar REFERENCES users(id),
+        created_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS user_follows (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        follower_id varchar REFERENCES users(id),
+        following_id varchar REFERENCES users(id),
+        created_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS social_posts (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id varchar REFERENCES users(id),
+        platform varchar NOT NULL, content text NOT NULL, type varchar NOT NULL,
+        title varchar, url varchar, media_url varchar,
+        project_id varchar REFERENCES projects(id),
+        likes integer DEFAULT 0, comments integer DEFAULT 0,
+        shares integer DEFAULT 0, views integer DEFAULT 0,
+        created_at timestamp DEFAULT now(), updated_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS social_connections (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id varchar REFERENCES users(id),
+        platform varchar NOT NULL, platform_user_id varchar, platform_username varchar,
+        access_token text, refresh_token text,
+        connected boolean DEFAULT true, followers integer DEFAULT 0,
+        created_at timestamp DEFAULT now(), updated_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS chat_messages (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        sender_id varchar REFERENCES users(id),
+        recipient_id varchar REFERENCES users(id),
+        conversation_id varchar NOT NULL, content text NOT NULL,
+        message_type varchar DEFAULT 'text', attachment_url varchar,
+        read_at timestamp, created_at timestamp DEFAULT now()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS collab_invites (
+        id serial PRIMARY KEY,
+        from_user_id text NOT NULL, to_user_id text NOT NULL,
+        project_id integer, type text NOT NULL, message text,
+        status text NOT NULL DEFAULT 'pending',
+        created_at timestamp DEFAULT now(), expires_at timestamp
+      )`;
+    console.log('✅ Migration: Social Hub tables ensured');
+
     console.log('✅ All migrations completed successfully');
   } catch (error) {
     // If columns already exist, that's fine

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -392,7 +392,7 @@ ${urls
   app.use("/api/voice-convert", createVoiceConvertRoutes(storage));
 
   // Mount Lyric Video Maker transcode route (WebM → MP4 for social sharing)
-  app.use("/api/lyric-video", createLyricVideoRoutes());
+  app.use("/api/lyric-video", createLyricVideoRoutes(storage));
 
   // Mount AI Stem Generation routes
   app.use("/api/stem-generation", createStemGenerationRoutes());
@@ -4214,6 +4214,8 @@ ${code}
       else if (ext === ".m4a") type = "audio/mp4";
       else if (ext === ".ogg") type = "audio/ogg";
       else if (ext === ".flac") type = "audio/flac";
+      else if (ext === ".mp4") type = "video/mp4";
+      else if (ext === ".webm") type = "video/webm";
       
       res.setHeader("Content-Type", type);
       res.setHeader("Accept-Ranges", "bytes");

--- a/server/routes/lyricVideo.ts
+++ b/server/routes/lyricVideo.ts
@@ -1,10 +1,11 @@
-// Lyric Video Maker — server-side WebM → MP4 transcode.
+// Lyric Video Maker — server-side WebM → MP4 transcode + share to Social Hub.
 //
 // The browser records the lyric video as WebM (the only format MediaRecorder
-// reliably produces), but WebM won't upload to iOS/Instagram/TikTok. This route
-// takes that WebM and returns a socially-compatible MP4 via the existing
-// fluent-ffmpeg dependency. No storage — the mp4 streams straight back for
-// download. See docs: approved in-chat design (2026-07-03).
+// reliably produces), but WebM won't upload to iOS/Instagram/TikTok. These
+// routes transcode it to a socially-compatible MP4 via the existing
+// fluent-ffmpeg dependency:
+//   POST /transcode  → returns the MP4 for direct download.
+//   POST /share      → stores the MP4 and creates a Social Hub video post.
 
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
@@ -15,6 +16,7 @@ import path from "path";
 import crypto from "crypto";
 import { requireAuth } from "../middleware/auth";
 import { buildTranscodeArgs } from "../lib/lyricVideoTranscode";
+import type { IStorage } from "../storage";
 
 // 50 MB matches the repo-wide multer convention (audioDebug/voiceConvert) and
 // comfortably covers a full-song 1080p WebM (~30-40 MB).
@@ -23,61 +25,105 @@ const videoUpload = multer({
   limits: { fileSize: 50 * 1024 * 1024, files: 1 },
 });
 
-export function createLyricVideoRoutes() {
+/** Transcode a WebM buffer to a temp MP4 file. Caller deletes both temp files. */
+async function transcodeToMp4(buffer: Buffer): Promise<{ mp4Path: string; webmPath: string }> {
+  const id = crypto.randomBytes(8).toString("hex");
+  const webmPath = path.join(os.tmpdir(), `lyric-video-${id}.webm`);
+  const mp4Path = path.join(os.tmpdir(), `lyric-video-${id}.mp4`);
+  fs.writeFileSync(webmPath, buffer);
+  await new Promise<void>((resolve, reject) => {
+    ffmpeg(webmPath)
+      .outputOptions(buildTranscodeArgs())
+      .on("end", () => resolve())
+      .on("error", (err) => reject(err))
+      .save(mp4Path);
+  });
+  return { mp4Path, webmPath };
+}
+
+export function createLyricVideoRoutes(storage: IStorage) {
   const router = Router();
 
+  // Transcode + return the MP4 for direct download.
   router.post(
     "/transcode",
     requireAuth(),
     videoUpload.single("video"),
     async (req: Request, res: Response) => {
       const file = req.file;
-      if (!file) {
-        return res.status(400).json({ success: false, message: "No video file uploaded" });
-      }
+      if (!file) return res.status(400).json({ success: false, message: "No video file uploaded" });
 
-      const id = crypto.randomBytes(8).toString("hex");
-      const inputPath = path.join(os.tmpdir(), `lyric-video-${id}.webm`);
-      const outputPath = path.join(os.tmpdir(), `lyric-video-${id}.mp4`);
-
+      let paths: { mp4Path: string; webmPath: string } | null = null;
       const cleanup = () => {
-        for (const p of [inputPath, outputPath]) {
-          try {
-            fs.unlinkSync(p);
-          } catch {
-            /* best-effort temp cleanup */
-          }
+        for (const p of [paths?.mp4Path, paths?.webmPath]) {
+          if (p) try { fs.unlinkSync(p); } catch { /* best-effort */ }
         }
       };
 
       try {
-        fs.writeFileSync(inputPath, file.buffer);
-
-        await new Promise<void>((resolve, reject) => {
-          ffmpeg(inputPath)
-            .outputOptions(buildTranscodeArgs())
-            .on("end", () => resolve())
-            .on("error", (err) => reject(err))
-            .save(outputPath);
-        });
-
-        const stat = fs.statSync(outputPath);
+        paths = await transcodeToMp4(file.buffer);
+        const stat = fs.statSync(paths.mp4Path);
         res.setHeader("Content-Type", "video/mp4");
         res.setHeader("Content-Length", stat.size);
         res.setHeader("Content-Disposition", 'attachment; filename="lyric-video.mp4"');
-
-        const stream = fs.createReadStream(outputPath);
-        // Clean up temp files once the response is fully sent (or the client aborts).
+        const stream = fs.createReadStream(paths.mp4Path);
         res.on("close", cleanup);
-        stream.on("error", () => {
-          cleanup();
-          if (!res.headersSent) res.status(500).end();
-        });
+        stream.on("error", () => { cleanup(); if (!res.headersSent) res.status(500).end(); });
         stream.pipe(res);
       } catch (error: any) {
         console.error("Lyric video transcode error:", error);
         cleanup();
         res.status(500).json({ success: false, message: error?.message || "Transcode failed" });
+      }
+    },
+  );
+
+  // Transcode, store the MP4, and create a Social Hub video post.
+  router.post(
+    "/share",
+    requireAuth(),
+    videoUpload.single("video"),
+    async (req: Request, res: Response) => {
+      const file = req.file;
+      if (!file) return res.status(400).json({ success: false, message: "No video file uploaded" });
+      if (!req.userId) return res.status(401).json({ success: false, message: "Authentication required" });
+
+      const caption = (req.body.caption as string | undefined)?.slice(0, 500) || "";
+      let paths: { mp4Path: string; webmPath: string } | null = null;
+      const cleanupTemp = () => {
+        for (const p of [paths?.mp4Path, paths?.webmPath]) {
+          if (p) try { fs.unlinkSync(p); } catch { /* best-effort */ }
+        }
+      };
+
+      try {
+        paths = await transcodeToMp4(file.buffer);
+
+        // Persist the MP4 into the objects dir served by GET /objects/* (same
+        // pattern as share-organism-session).
+        const objDir = process.env.LOCAL_OBJECTS_DIR || path.join(process.cwd(), "objects");
+        const vidDir = path.join(objDir, "lyric-videos");
+        if (!fs.existsSync(vidDir)) fs.mkdirSync(vidDir, { recursive: true });
+        const filename = `${crypto.randomBytes(12).toString("hex")}.mp4`;
+        fs.copyFileSync(paths.mp4Path, path.join(vidDir, filename));
+        const mediaUrl = `/objects/lyric-videos/${filename}`;
+
+        const post = await storage.createSocialPost(req.userId, {
+          platform: "codedswitch",
+          type: "lyric-video",
+          title: "Lyric Video",
+          content: JSON.stringify({ caption }),
+          url: `${process.env.PUBLIC_URL || ""}/social-hub`,
+          mediaUrl,
+          likes: 0, comments: 0, shares: 0, views: 0,
+        });
+
+        res.json({ success: true, post, mediaUrl });
+      } catch (error: any) {
+        console.error("Lyric video share error:", error);
+        res.status(500).json({ success: false, message: error?.message || "Share failed" });
+      } finally {
+        cleanupTemp();
       }
     },
   );


### PR DESCRIPTION
Delivers the approved **lyric video → Social Hub** feature and repairs the Social Hub itself.

## Social Hub was fully broken in prod
Every action 500'd — its tables (`social_posts`, `chat_messages`, `collab_invites`, …) were defined in `shared/schema.ts` but never pushed to prod (`relation "social_posts" does not exist`, confirmed in Railway logs). **Prod is already patched** via an additive `CREATE TABLE IF NOT EXISTS` migration; this PR also folds those statements into `runMigrations.ts` so fresh DBs self-heal, and commits the `.sql` as a record.

## Lyric video → feed
- **`POST /api/lyric-video/share`** — transcode WebM→MP4, store under `objects/lyric-videos`, create a `type=lyric-video` post with the MP4 as `mediaUrl`.
- **`LyricVideoMaker`** — extracted `recordToWebm()`; added a **"Share to Feed"** button beside Export (both reuse the recorder).
- **Feed card renders `<video>`** for video posts (was audio-only — the core "needs work" gap).
- **`GET /objects/*`** now serves `video/mp4` / `video/webm` (was `octet-stream`, which broke `<video>`).

## Verification
- `tsc --noEmit` — 0 errors
- Unit tests — 5/5 pass
- Prod feed endpoint already returns 200 after the DB patch

## Noted fast-follow (out of scope)
Storage uses the local `objects/` dir like `share-organism-session`; on Railway that's ephemeral across redeploys. GCS (`ObjectStorageService`) persistence is the hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)