### PR TITLE
fix(studio): lyric videos no longer drop words Whisper didn't timestamp

### DIFF
--- a/client/src/lib/__tests__/lyricVideoTiming.test.ts
+++ b/client/src/lib/__tests__/lyricVideoTiming.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  alignTimedWordsToTranscript,
   buildLyricVideoLines,
   findActiveLyricLine,
   normalizeTimedWords,
@@ -20,6 +21,37 @@ describe('lyricVideoTiming', () => {
     const line = { id: 'l', text: 'a', start: 8, end: 9, words: [] };
     expect(resolveLyricLineTiming(line, {}).displayStart).toBeCloseTo(8, 5);
     expect(resolveLyricLineTiming(line, { speed: 0 }).displayStart).toBeCloseTo(8, 5);
+  });
+
+  it('keeps every transcript word even when Whisper dropped some (missing-words bug)', () => {
+    // Whisper's word array is missing "brown", but the transcript has it.
+    const aligned = alignTimedWordsToTranscript('the quick brown fox', [
+      { text: 'the', start: 0, end: 0.4 },
+      { text: 'quick', start: 1, end: 1.4 },
+      { text: 'fox', start: 3, end: 3.4 },
+    ]);
+    expect(aligned.map((w) => w.text)).toEqual(['the', 'quick', 'brown', 'fox']);
+    // matched words keep real timing
+    expect(aligned[0].start).toBeCloseTo(0, 5);
+    expect(aligned[3].start).toBeCloseTo(3, 5);
+    // the dropped word gets a time between its neighbors (1 → 3)
+    expect(aligned[2].start).toBeGreaterThan(1);
+    expect(aligned[2].start).toBeLessThan(3);
+  });
+
+  it('zips timing 1:1 when transcript and timings match, ignoring punctuation', () => {
+    const aligned = alignTimedWordsToTranscript('Hello world,', [
+      { text: 'hello', start: 0, end: 0.5 },
+      { text: 'world', start: 1, end: 1.5 },
+    ]);
+    expect(aligned.map((w) => w.text)).toEqual(['Hello', 'world,']);
+    expect(aligned[1].start).toBeCloseTo(1, 5);
+  });
+
+  it('falls back to timings when transcript is empty, and to [] when no timings', () => {
+    const timed = [{ text: 'a', start: 0, end: 0.3 }];
+    expect(alignTimedWordsToTranscript('', timed)).toEqual(timed);
+    expect(alignTimedWordsToTranscript('some words here', [])).toEqual([]);
   });
 
   it('normalizes OpenAI word timestamp shapes', () => {

--- a/client/src/lib/lyricVideoTiming.ts
+++ b/client/src/lib/lyricVideoTiming.ts
@@ -80,6 +80,80 @@ export function normalizeTimedWords(input: unknown): TimedLyricWord[] {
     .sort((a, b) => a.start - b.start);
 }
 
+const normalizeToken = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/gi, '');
+
+/**
+ * Make the (complete, user-editable) transcript the authoritative word list and
+ * attach Whisper timings to it. Every transcript word survives; words Whisper
+ * matched keep their real time; words it dropped get a time interpolated from
+ * their timed neighbours. Fixes on-screen words going missing when Whisper's
+ * per-word array omits words the transcript still has.
+ */
+export function alignTimedWordsToTranscript(
+  transcript: string,
+  timedWords: TimedLyricWord[],
+): TimedLyricWord[] {
+  const tokens = transcript.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return timedWords;
+  if (timedWords.length === 0) return [];
+
+  const slots: Array<{ text: string; start?: number; end?: number }> = tokens.map((text) => ({ text }));
+
+  // Greedy in-order match: assign each timed word to the next transcript token
+  // whose normalized text equals it. Unmatched transcript tokens stay untimed.
+  let j = 0;
+  for (let i = 0; i < slots.length && j < timedWords.length; i += 1) {
+    if (normalizeToken(slots[i].text) === normalizeToken(timedWords[j].text)) {
+      slots[i].start = timedWords[j].start;
+      slots[i].end = timedWords[j].end;
+      j += 1;
+    }
+  }
+
+  // If tokenization diverged too much to match anything, spread timings evenly.
+  if (!slots.some((slot) => slot.start !== undefined)) {
+    const n = slots.length;
+    const m = timedWords.length;
+    slots.forEach((slot, i) => {
+      const k = n === 1 ? 0 : Math.round((i * (m - 1)) / (n - 1));
+      slot.start = timedWords[k].start;
+      slot.end = timedWords[k].end;
+    });
+  }
+
+  const firstStart = slots.find((slot) => slot.start !== undefined)?.start ?? 0;
+  const lastEnd = [...slots].reverse().find((slot) => slot.end !== undefined)?.end ?? firstStart + 0.35;
+
+  // Interpolate untimed runs between the surrounding timed anchors.
+  let i = 0;
+  while (i < slots.length) {
+    if (slots[i].start !== undefined) {
+      i += 1;
+      continue;
+    }
+    let k = i;
+    while (k < slots.length && slots[k].start === undefined) k += 1;
+    const before = i > 0 ? slots[i - 1] : undefined;
+    const after = k < slots.length ? slots[k] : undefined;
+    const startAnchor = before?.end ?? before?.start ?? firstStart;
+    const endAnchor = after?.start ?? lastEnd;
+    const count = k - i;
+    for (let g = 0; g < count; g += 1) {
+      const frac = (g + 1) / (count + 1);
+      const start = Math.max(0, startAnchor + (endAnchor - startAnchor) * frac);
+      slots[i + g].start = start;
+      slots[i + g].end = start + Math.max(0.12, (endAnchor - startAnchor) / (count + 1));
+    }
+    i = k;
+  }
+
+  return slots.map((slot) => ({
+    text: slot.text,
+    start: slot.start ?? 0,
+    end: slot.end !== undefined && slot.end > (slot.start ?? 0) ? slot.end : (slot.start ?? 0) + 0.35,
+  }));
+}
+
 export function buildLyricVideoLines({
   words,
   transcript = '',
@@ -87,7 +161,11 @@ export function buildLyricVideoLines({
   bpm = DEFAULT_BPM,
 }: LyricVideoLineOptions): LyricVideoLine[] {
   const groupSize = clampInt(wordsPerLine, 1, 12);
-  const timedWords = normalizeTimedWords(words);
+  // The transcript is the complete word list; align Whisper timings onto it so
+  // no spoken word is dropped from the screen.
+  const timedWords = transcript.trim()
+    ? alignTimedWordsToTranscript(transcript, normalizeTimedWords(words))
+    : normalizeTimedWords(words);
 
   if (timedWords.length > 0) {
     return chunkWords(timedWords.map((word) => word.text), groupSize).map((chunk, index) => {


### PR DESCRIPTION
## Bug
Words that were in the transcript were **missing on screen** in the exported/previewed lyric video.

## Root cause
`buildLyricVideoLines` built lines **only from Whisper's per-word timing array** and ignored the transcript text. That array is a *subset* of the transcript — Whisper drops/merges words (especially over beats or fast rap), and `normalizeTimedWords` discards any word missing a timestamp. So the screen showed fewer words than the transcript, and editing the transcript did nothing.

## Fix
The **transcript is now the authoritative word list** (complete and user-editable). `alignTimedWordsToTranscript()` attaches Whisper timings to it via in-order, punctuation-insensitive matching; any transcript word Whisper dropped gets a timestamp interpolated from its timed neighbours. Result: every spoken word appears, and transcript edits now affect the video.

## Verification
- Timing unit tests **10/10** (3 new: dropped-word alignment, 1:1 zip w/ punctuation, empty-input fallbacks)
- `tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)